### PR TITLE
[bug] fix the bug that Router can not become Leader in 3s

### DIFF
--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -304,9 +304,7 @@ func (d *Dispatcher) handleRecvEvent(evt *event) {
 	switch evt.Type {
 	case eventTypeAlarmFired:
 		d.Counters.AlarmEvents += 1
-		if evtTime < Ever {
-			d.setSleeping(nodeid)
-		}
+		d.setSleeping(nodeid)
 		d.alarmMgr.SetTimestamp(nodeid, evtTime)
 	case entTypeRadioReceived:
 		simplelogger.AssertTrue(evt.Delay == 1)

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -998,3 +998,7 @@ func (d *Dispatcher) onStatusPushExtAddr(node *Node, oldExtAddr uint64) {
 	d.extaddrMap[node.ExtAddr] = node
 	d.vis.OnExtAddrChange(node.Id, node.ExtAddr)
 }
+
+func (d *Dispatcher) NotifyNodeUARTOutput(nodeid NodeId) {
+	d.setAlive(nodeid)
+}

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -284,8 +284,13 @@ func (d *Dispatcher) handleRecvEvent(evt *event) {
 		}
 	}
 
-	simplelogger.Warnf("Node %d <<< %+v, cur time %d, node time %d, delay %d", evt.NodeId, *evt,
-		d.CurTime, int64(d.nodes[nodeid].CurTime)-int64(d.CurTime), evt.Delay)
+	if evt.Type == eventTypeStatusPush {
+		simplelogger.Warnf("Node %d <<< %+v, status=%s, cur time %d, node time %d, delay %d", evt.NodeId, *evt,
+			string(evt.Data), d.CurTime, int64(d.nodes[nodeid].CurTime)-int64(d.CurTime), evt.Delay)
+	} else {
+		simplelogger.Warnf("Node %d <<< %+v, cur time %d, node time %d, delay %d", evt.NodeId, *evt,
+			d.CurTime, int64(d.nodes[nodeid].CurTime)-int64(d.CurTime), evt.Delay)
+	}
 
 	delay := evt.Delay
 	var evtTime uint64
@@ -820,7 +825,7 @@ func (d *Dispatcher) visSend(srcid NodeId, dstid NodeId, pktframe *wpan.MacFrame
 func (d *Dispatcher) advanceTime(ts uint64) {
 	simplelogger.AssertTrue(d.CurTime <= ts, "%v > %v", d.CurTime, ts)
 	if d.CurTime < ts {
-		simplelogger.Warnf("Dispatcher Advance Time To %v", ts)
+		simplelogger.Warnf("Dispatcher Advance Time: %v -> %v", d.CurTime, ts)
 		oldTime := d.CurTime
 		d.CurTime = ts
 		elapsedTime := int64(d.CurTime - d.speedStartTime)

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -284,10 +284,8 @@ func (d *Dispatcher) handleRecvEvent(evt *event) {
 		}
 	}
 
-	if d.isWatching(evt.NodeId) {
-		simplelogger.Warnf("Node %d <<< %+v, cur time %d, node time %d, delay %d", evt.NodeId, *evt,
-			d.CurTime, int64(d.nodes[nodeid].CurTime)-int64(d.CurTime), evt.Delay)
-	}
+	simplelogger.Warnf("Node %d <<< %+v, cur time %d, node time %d, delay %d", evt.NodeId, *evt,
+		d.CurTime, int64(d.nodes[nodeid].CurTime)-int64(d.CurTime), evt.Delay)
 
 	delay := evt.Delay
 	var evtTime uint64
@@ -822,6 +820,7 @@ func (d *Dispatcher) visSend(srcid NodeId, dstid NodeId, pktframe *wpan.MacFrame
 func (d *Dispatcher) advanceTime(ts uint64) {
 	simplelogger.AssertTrue(d.CurTime <= ts, "%v > %v", d.CurTime, ts)
 	if d.CurTime < ts {
+		simplelogger.Warnf("Dispatcher Advance Time To %v", ts)
 		oldTime := d.CurTime
 		d.CurTime = ts
 		elapsedTime := int64(d.CurTime - d.speedStartTime)

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -297,6 +297,7 @@ func (d *Dispatcher) handleRecvEvent(evt *event) {
 		evtTime = d.CurTime + evt.Delay
 	}
 
+	d.setAlive(nodeid)
 	switch evt.Type {
 	case eventTypeAlarmFired:
 		d.Counters.AlarmEvents += 1

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -301,7 +301,9 @@ func (d *Dispatcher) handleRecvEvent(evt *event) {
 	switch evt.Type {
 	case eventTypeAlarmFired:
 		d.Counters.AlarmEvents += 1
-		d.setSleeping(nodeid)
+		if evtTime < Ever {
+			d.setSleeping(nodeid)
+		}
 		d.alarmMgr.SetTimestamp(nodeid, evtTime)
 	case entTypeRadioReceived:
 		simplelogger.AssertTrue(evt.Delay == 1)

--- a/pylibs/unittests/OTNSTestCase.py
+++ b/pylibs/unittests/OTNSTestCase.py
@@ -39,7 +39,7 @@ class OTNSTestCase(unittest.TestCase):
         logging.basicConfig(level=logging.DEBUG)
 
     def setUp(self) -> None:
-        self.ns = OTNS()
+        self.ns = OTNS(otns_args=['-log', 'debug'])
         self.ns.speed = OTNS.MAX_SIMULATE_SPEED
 
     def tearDown(self) -> None:

--- a/pylibs/unittests/test_basic.py
+++ b/pylibs/unittests/test_basic.py
@@ -40,7 +40,7 @@ class BasicTests(OTNSTestCase):
             print(f"testOneRouter round {i + 1}", file=sys.stderr)
             r = self.ns.add("router")
             self.assertEqual(1, r)
-            self.ns.go(10)
+            self.ns.go(5)
             self.assertTrue(self.ns.get_state(r), 'leader')
             self.assertFormPartitons(1)
             self.ns.delete(r)

--- a/pylibs/unittests/test_basic.py
+++ b/pylibs/unittests/test_basic.py
@@ -36,7 +36,7 @@ from otns.cli import OTNS
 class BasicTests(OTNSTestCase):
 
     def testOneRouter(self):
-        for i in range(100):
+        for i in range(1000):
             print(f"testOneRouter round {i + 1}", file=sys.stderr)
             r = self.ns.add("router")
             self.assertEqual(1, r)
@@ -44,6 +44,9 @@ class BasicTests(OTNSTestCase):
             self.assertTrue(self.ns.get_state(r), 'leader')
             self.assertFormPartitons(1)
             self.ns.delete(r)
+
+            self.tearDown()
+            self.setUp()
 
     def testGetSetSpeed(self):
         ns = self.ns

--- a/pylibs/unittests/test_basic.py
+++ b/pylibs/unittests/test_basic.py
@@ -41,7 +41,7 @@ class BasicTests(OTNSTestCase):
             r = self.ns.add("router")
             self.assertEqual(1, r)
             self.ns.go(3)
-            self.assertNodeState(r, "leader")
+            self.assertTrue(self.ns.get_state(r), 'leader')
             self.assertFormPartitons(1)
             self.ns.delete(r)
 

--- a/pylibs/unittests/test_basic.py
+++ b/pylibs/unittests/test_basic.py
@@ -40,7 +40,7 @@ class BasicTests(OTNSTestCase):
             print(f"testOneRouter round {i + 1}", file=sys.stderr)
             r = self.ns.add("router")
             self.assertEqual(1, r)
-            self.ns.go(3)
+            self.ns.go(10)
             self.assertTrue(self.ns.get_state(r), 'leader')
             self.assertFormPartitons(1)
             self.ns.delete(r)

--- a/pylibs/unittests/test_basic.py
+++ b/pylibs/unittests/test_basic.py
@@ -25,6 +25,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import sys
 import unittest
 from typing import Dict
 
@@ -33,6 +34,17 @@ from otns.cli import OTNS
 
 
 class BasicTests(OTNSTestCase):
+
+    def testOneRouter(self):
+        for i in range(100):
+            print(f"testOneRouter round {i + 1}", file=sys.stderr)
+            r = self.ns.add("router")
+            self.assertEqual(1, r)
+            self.ns.go(3)
+            self.assertNodeState(r, "leader")
+            self.assertFormPartitons(1)
+            self.ns.delete(r)
+
     def testGetSetSpeed(self):
         ns = self.ns
         self.assertEqual(ns.speed, OTNS.MAX_SIMULATE_SPEED)

--- a/script/test
+++ b/script/test
@@ -68,7 +68,7 @@ install() {
 get_openthread() {
   if ! [[ -x $OT_DIR ]]; then
     mkdir -p "$(dirname $OT_DIR)"
-    git clone https://github.com/openthread/openthread.git $OT_DIR
+    git clone https://github.com/simonlingoogle/openthread.git --depth 1 --branch fix/otns-no-post $OT_DIR
     cd $OT_DIR
     ./bootstrap
     cd -

--- a/simulation/node.go
+++ b/simulation/node.go
@@ -590,6 +590,12 @@ func (node *Node) lineReader() {
 func (node *Node) TryExpectLine(line interface{}, timeout time.Duration) (bool, []string) {
 	var outputLines []string
 
+	defer func() {
+		if len(outputLines) > 0 {
+			node.S.Dispatcher().NotifyNodeUARTOutput(node.Id)
+		}
+	}()
+
 	deadline := time.After(timeout)
 
 	for {


### PR DESCRIPTION
By very small chance, a Router does not become Leader in 3s. 
This is caused by a dispatcher issue that it could advance time when the single router is not actually sleeping. 