### PR TITLE
[simulation] support virtual time UART

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,12 +53,15 @@ jobs:
           ./script/test go-tests
 
   py-unittests:
-    name: Python${{ matrix.python-version }} Unittests on ${{ matrix.os }}
+    name: Unittests (Py${{ matrix.python-version }}, ${{ matrix.os }}, VIRTUAL_TIME_UART=${{ matrix.VIRTUAL_TIME_UART }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: [3.6]
         os: [ubuntu-latest, macos-10.15]
+        VIRTUAL_TIME_UART: [0, 1]
+    env:
+      VIRTUAL_TIME_UART: ${{ matrix.VIRTUAL_TIME_UART }}
     steps:
       - uses: actions/setup-go@v1
         with:
@@ -73,12 +76,15 @@ jobs:
           ./script/test py-unittests
 
   py-examples:
-    name: Examples (Py${{ matrix.python-version }}, ${{ matrix.os }})
+    name: Examples (Py${{ matrix.python-version }}, ${{ matrix.os }}, VIRTUAL_TIME_UART=${{ matrix.VIRTUAL_TIME_UART }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: [3.6]
         os: [ubuntu-latest, macos-10.15]
+        VIRTUAL_TIME_UART: [0, 1]
+    env:
+      VIRTUAL_TIME_UART: ${{ matrix.VIRTUAL_TIME_UART }}
     steps:
       - uses: actions/setup-go@v1
         with:
@@ -86,15 +92,17 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run Examples
         run: |
+          export VIRTUAL_TIME_UART=${{ matrix.VIRTUAL_TIME_UART }}
           ./script/test py-examples
 
   signals:
-    name: Signals (Py${{ matrix.python-version }}, ${{ matrix.os }})
+    name: Signals (Py${{ matrix.python-version }}, ${{ matrix.os }}, VIRTUAL_TIME_UART=${{ matrix.VIRTUAL_TIME_UART }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: [3.6]
         os: [ubuntu-latest, macos-10.15]
+        VIRTUAL_TIME_UART: [0, 1]
     steps:
       - uses: actions/setup-go@v1
         with:

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -535,8 +535,8 @@ func (d *Dispatcher) advanceNodeTime(id NodeId, timestamp uint64, force bool) {
 	}
 }
 
-// SendUART sends data to virtual time UART of the target node.
-func (d *Dispatcher) SendUART(id NodeId, data []byte) {
+// SendToUART sends data to virtual time UART of the target node.
+func (d *Dispatcher) SendToUART(id NodeId, data []byte) {
 	simplelogger.AssertTrue(d.cfg.VirtualTimeUART)
 
 	node := d.nodes[id]
@@ -1131,7 +1131,7 @@ func (d *Dispatcher) handleUartWrite(nodeid NodeId, data []byte) {
 	d.cbHandler.OnUartWrite(nodeid, data)
 }
 
-// NotifyExit notifies the dispatcher that the node process has exit.
+// NotifyExit notifies the dispatcher that the node process has exited.
 func (d *Dispatcher) NotifyExit(nodeid NodeId) {
 	d.setSleeping(nodeid)
 }

--- a/dispatcher/event.go
+++ b/dispatcher/event.go
@@ -31,6 +31,7 @@ import . "github.com/openthread/ot-ns/types"
 const (
 	eventTypeAlarmFired    = 0
 	eventTypeRadioReceived = 1
+	eventTypeUartWrite     = 2
 	eventTypeStatusPush    = 5
 )
 

--- a/otns_main/otns_main.go
+++ b/otns_main/otns_main.go
@@ -194,7 +194,20 @@ func createSimulation(ctx *progctx.ProgCtx) *simulation.Simulation {
 	simcfg.RawMode = args.RawMode
 	simcfg.Real = args.Real
 
+	simcfg.VirtualTimeUART = parseVirtualTimeUARTFromEnviron()
+
 	sim, err := simulation.NewSimulation(ctx, simcfg)
 	simplelogger.FatalIfError(err)
 	return sim
+}
+
+func parseVirtualTimeUARTFromEnviron() bool {
+	val := os.Getenv("VIRTUAL_TIME_UART")
+	if val == "" {
+		val = "0"
+	}
+	simplelogger.Infof("env VIRTUAL_TIME_UART=%s", val)
+	ival, err := strconv.Atoi(val)
+	simplelogger.FatalfIfError(err, "invalid VIRTUAL_TIME_UART: %s", val)
+	return ival != 0
 }

--- a/otns_main/otns_main.go
+++ b/otns_main/otns_main.go
@@ -194,14 +194,14 @@ func createSimulation(ctx *progctx.ProgCtx) *simulation.Simulation {
 	simcfg.RawMode = args.RawMode
 	simcfg.Real = args.Real
 
-	simcfg.VirtualTimeUART = parseVirtualTimeUARTFromEnviron()
+	simcfg.VirtualTimeUART = parseVirtualTimeUARTFromEnv()
 
 	sim, err := simulation.NewSimulation(ctx, simcfg)
 	simplelogger.FatalIfError(err)
 	return sim
 }
 
-func parseVirtualTimeUARTFromEnviron() bool {
+func parseVirtualTimeUARTFromEnv() bool {
 	val := os.Getenv("VIRTUAL_TIME_UART")
 	if val == "" {
 		val = "0"

--- a/pylibs/examples/form_partition.py
+++ b/pylibs/examples/form_partition.py
@@ -37,7 +37,7 @@ RADIO_RANGE = 150
 
 
 def main():
-    ns = OTNS()
+    ns = OTNS(otns_args=["-log", "debug"])
     ns.web()
     ns.speed = float('inf')
 

--- a/pylibs/unittests/OTNSTestCase.py
+++ b/pylibs/unittests/OTNSTestCase.py
@@ -25,10 +25,13 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 import logging
+import os
 import tracemalloc
 import unittest
 
 from otns.cli import OTNS
+
+_NON_VIRTUAL_TIME_UART_CONSERVATIVE_FACTOR = 1 if os.getenv('VIRTUAL_TIME_UART') == '1' else 3
 
 
 class OTNSTestCase(unittest.TestCase):
@@ -36,7 +39,7 @@ class OTNSTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         tracemalloc.start()
-        logging.basicConfig(level=logging.DEBUG)
+        logging.basicConfig(level=logging.DEBUG, format='%(asctime)-15s - %(levelname)s - %(message)s')
 
     def setUp(self) -> None:
         self.ns = OTNS(otns_args=['-log', 'debug'])
@@ -48,3 +51,12 @@ class OTNSTestCase(unittest.TestCase):
     def assertFormPartitions(self, count: int):
         pars = self.ns.partitions()
         self.assertTrue(len(pars) == count and 0 not in pars, pars)
+
+    def goConservative(self, duration: float) -> None:
+        """
+        Run the simulation for a given duration.
+
+        :param duration: the duration to simulate (multipled by `_NON_VIRTUAL_TIME_UART_CONSERVATIVE_FACTOR`
+                         if virtual time UART is not used)
+        """
+        self.ns.go(duration * _NON_VIRTUAL_TIME_UART_CONSERVATIVE_FACTOR)

--- a/pylibs/unittests/test_commissioning.py
+++ b/pylibs/unittests/test_commissioning.py
@@ -44,7 +44,7 @@ class BasicTests(OTNSTestCase):
         ns = self.ns
         ns.add("router")
         ns.add("router")
-        ns.go(100)
+        self.goConservative(10)
         # can not form any partition without setting network parameters
         self.assertTrue(0 in ns.partitions())
 
@@ -60,7 +60,7 @@ class BasicTests(OTNSTestCase):
             ns.ifconfig_up(id)
             ns.thread_start(id)
 
-        ns.go(100)
+        self.goConservative(30)
         self.assertFormPartitions(1)
 
     def testCommissioning(self):
@@ -73,16 +73,16 @@ class BasicTests(OTNSTestCase):
         ns.node_cmd(n1, "dataset commit active")
         ns.ifconfig_up(n1)
         ns.thread_start(n1)
-        ns.go(100)
+        self.goConservative(30)
         self.assertTrue(ns.get_state(n1) == "leader")
         ns.commissioner_start(n1)
         ns.commissioner_joiner_add(n1, "*", "TEST123")
 
         ns.ifconfig_up(n2)
         ns.joiner_start(n2, "TEST123")
-        ns.go(100)
+        self.goConservative(100)
         ns.thread_start(n2)
-        ns.go(100)
+        self.goConservative(100)
         c = ns.counters()
         print('countes', c)
         joins = ns.joins()

--- a/pylibs/unittests/test_signals.py
+++ b/pylibs/unittests/test_signals.py
@@ -26,6 +26,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
+import os
 import logging
 import os
 import signal
@@ -100,10 +101,10 @@ class SignalsTest(OTNSTestCase):
         t.join()
         self.assertRaises(TimeoutExpired, self.ns._otns.wait, timeout=0.1)
 
-        self.ns._otns.send_signal(signal.SIGKILL)
+        self.ns._otns.send_signal(signal.SIGTERM)
         t2.join()
         exit_code = self.ns._otns.wait()
-        self.assertNotEqual(0, exit_code, "exit code should not be 0")
+        self.assertEqual(0, exit_code, "exit code should be 0")
 
     def _test_signal_exit(self, sig: int, duration: float = 1):
         self._setup_simulation()
@@ -121,6 +122,8 @@ class SignalsTest(OTNSTestCase):
 
         if sig == signal.SIGKILL:
             self.assertNotEqual(0, exit_code, "exit code should not be 0")
+            # Kill all ot-cli-ftd child processes.
+            os.system('killall -KILL ot-cli-ftd')
         else:
             self.assertEqual(0, exit_code, "exit code should be 0")
 

--- a/simulation/node.go
+++ b/simulation/node.go
@@ -180,7 +180,7 @@ func (node *Node) AssurePrompt() {
 
 func (node *Node) inputCommand(cmd string) {
 	if node.S.cfg.VirtualTimeUART {
-		node.S.Dispatcher().SendUART(node.Id, []byte(cmd+"\n"))
+		node.S.Dispatcher().SendToUART(node.Id, []byte(cmd+"\n"))
 	} else {
 		_, _ = node.pipeIn.Write([]byte(cmd + "\n"))
 	}

--- a/simulation/node.go
+++ b/simulation/node.go
@@ -65,17 +65,31 @@ func newNode(s *Simulation, id NodeId, cfg *NodeConfig) (*Node, error) {
 	}
 	simplelogger.Debugf("node exe path: %s", exePath)
 	cmd := exec.CommandContext(context.Background(), exePath, strconv.Itoa(id))
-	pipeIn, err := cmd.StdinPipe()
-	if err != nil {
-		return nil, err
+
+	node := &Node{
+		S:            s,
+		Id:           id,
+		cfg:          cfg,
+		cmd:          cmd,
+		pendingLines: make(chan string, 100),
 	}
 
-	pipeOut, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, err
+	if s.cfg.VirtualTimeUART {
+		node.virtualUartReader, node.virtualUartPipe = io.Pipe()
+		node.pipeOut = bufio.NewReader(node.virtualUartReader)
+	} else {
+		if node.pipeIn, err = cmd.StdinPipe(); err != nil {
+			return nil, err
+		}
+
+		if node.pipeOut, err = cmd.StdoutPipe(); err != nil {
+			return nil, err
+		}
+
+		node.pipeOut = bufio.NewReader(node.pipeOut)
 	}
 
-	pipeOutErr, err := cmd.StderrPipe()
+	node.pipeErr, err = cmd.StderrPipe()
 	if err != nil {
 		return nil, err
 	}
@@ -85,22 +99,8 @@ func newNode(s *Simulation, id NodeId, cfg *NodeConfig) (*Node, error) {
 		return nil, err
 	}
 
-	n := &Node{
-		S:            s,
-		Id:           id,
-		cfg:          cfg,
-		cmd:          cmd,
-		Input:        pipeIn,
-		Output:       bufio.NewReader(pipeOut),
-		outputErr:    pipeOutErr,
-		pendingLines: make(chan string, 100),
-	}
-
-	go n.lineReader()
-
-	n.AssurePrompt()
-
-	return n, nil
+	go node.lineReader()
+	return node, nil
 }
 
 type Node struct {
@@ -109,11 +109,14 @@ type Node struct {
 	cfg *NodeConfig
 
 	cmd       *exec.Cmd
-	Input     io.WriteCloser
-	Output    io.Reader
 	outputErr io.Reader
 
-	pendingLines chan string
+	pendingLines      chan string
+	pipeIn            io.WriteCloser
+	pipeOut           io.Reader
+	pipeErr           io.ReadCloser
+	virtualUartReader *io.PipeReader
+	virtualUartPipe   *io.PipeWriter
 }
 
 func (node *Node) String() string {
@@ -146,37 +149,50 @@ func (node *Node) Stop() {
 }
 
 func (node *Node) Exit() error {
-	_, _ = node.Input.Write([]byte("exit\n"))
-	node.expectEOF(DefaultCommandTimeout)
-	err := node.cmd.Wait()
-	if err != nil {
-		simplelogger.Warnf("%s exit error: %+v", node, err)
+	if node.S.cfg.VirtualTimeUART {
+		_ = node.cmd.Process.Kill()
+		_ = node.virtualUartReader.Close()
+	} else {
+		node.inputCommand("exit")
 	}
+	node.expectEOF(DefaultCommandTimeout)
+
+	err := node.cmd.Wait()
+	node.S.Dispatcher().NotifyExit(node.Id)
+
 	return err
 }
 
 func (node *Node) AssurePrompt() {
-	_, _ = node.Input.Write([]byte("\n"))
+	node.inputCommand("")
 	if found, _ := node.TryExpectLine("", time.Second); found {
 		return
 	}
 
-	_, _ = node.Input.Write([]byte("\n"))
+	node.inputCommand("")
 	if found, _ := node.TryExpectLine("", time.Second); found {
 		return
 	}
 
-	_, _ = node.Input.Write([]byte("\n"))
+	node.inputCommand("")
 	node.expectLine("", DefaultCommandTimeout)
 }
 
+func (node *Node) inputCommand(cmd string) {
+	if node.S.cfg.VirtualTimeUART {
+		node.S.Dispatcher().SendUART(node.Id, []byte(cmd+"\n"))
+	} else {
+		_, _ = node.pipeIn.Write([]byte(cmd + "\n"))
+	}
+}
+
 func (node *Node) CommandExpectNone(cmd string, timeout time.Duration) {
-	_, _ = node.Input.Write([]byte(cmd + "\n"))
+	node.inputCommand(cmd)
 	node.expectLine(cmd, timeout)
 }
 
 func (node *Node) Command(cmd string, timeout time.Duration) []string {
-	_, _ = node.Input.Write([]byte(cmd + "\n"))
+	node.inputCommand(cmd)
 	node.expectLine(cmd, timeout)
 	output := node.expectLine(DoneOrErrorRegexp, timeout)
 
@@ -464,14 +480,14 @@ func (node *Node) SetLeaderWeight(weight int) {
 
 func (node *Node) FactoryReset() {
 	simplelogger.Warnf("%v - factoryreset", node)
-	_, _ = node.Input.Write([]byte("factoryreset\n"))
+	node.inputCommand("factoryreset")
 	node.AssurePrompt()
 	simplelogger.Debugf("%v - ready", node)
 }
 
 func (node *Node) Reset() {
 	simplelogger.Warnf("%v - reset", node)
-	_, _ = node.Input.Write([]byte("reset\n"))
+	node.inputCommand("reset")
 	node.AssurePrompt()
 	simplelogger.Debugf("%v - ready", node)
 }
@@ -561,14 +577,8 @@ func (node *Node) lineReader() {
 	// close the line channel after line reader routine exit
 	defer close(node.pendingLines)
 
-	scanner := bufio.NewScanner(otoutfilter.NewOTOutFilter(node.Output, node.String()))
+	scanner := bufio.NewScanner(otoutfilter.NewOTOutFilter(node.pipeOut, node.String()))
 	scanner.Split(bufio.ScanLines)
-
-	defer func() {
-		if scanner.Err() != nil {
-			simplelogger.Errorf("%v read input error: %v", node, scanner.Err())
-		}
-	}()
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -618,6 +628,8 @@ func (node *Node) TryExpectLine(line interface{}, timeout time.Duration) (bool, 
 					fmt.Printf("%s\n", readLine)
 				}
 			}
+		default:
+			node.S.Dispatcher().RecvEvents()
 		}
 	}
 }
@@ -663,7 +675,7 @@ func (node *Node) CommandExpectEnabledOrDisabled(cmd string, timeout time.Durati
 
 func (node *Node) Ping(addr string, payloadSize int, count int, interval int, hopLimit int) {
 	cmd := fmt.Sprintf("ping %s %d %d %d %d", addr, payloadSize, count, interval, hopLimit)
-	_, _ = node.Input.Write([]byte(cmd + "\n"))
+	node.inputCommand(cmd)
 	node.expectLine(cmd, DefaultCommandTimeout)
 	node.AssurePrompt()
 }
@@ -717,4 +729,8 @@ func (node *Node) setupMode() {
 	} else {
 		node.SetRouterSelectionJitter(1)
 	}
+}
+
+func (node *Node) onUartWrite(data []byte) {
+	_, _ = node.virtualUartPipe.Write(data)
 }

--- a/simulation/simulation_config.go
+++ b/simulation/simulation_config.go
@@ -34,27 +34,29 @@ const (
 )
 
 type Config struct {
-	NetworkName string
-	MasterKey   string
-	Panid       uint16
-	Channel     int
-	OtCliPath   string
-	Speed       float64
-	ReadOnly    bool
-	RawMode     bool
-	Real        bool
+	NetworkName     string
+	MasterKey       string
+	Panid           uint16
+	Channel         int
+	OtCliPath       string
+	Speed           float64
+	ReadOnly        bool
+	RawMode         bool
+	Real            bool
+	VirtualTimeUART bool
 }
 
 func DefaultConfig() *Config {
 	return &Config{
-		NetworkName: DefaultNetworkName,
-		MasterKey:   DefaultMasterKey,
-		Panid:       DefaultPanid,
-		Channel:     DefaultChannel,
-		Speed:       1,
-		ReadOnly:    false,
-		RawMode:     false,
-		OtCliPath:   "ot-cli-ftd",
-		Real:        false,
+		NetworkName:     DefaultNetworkName,
+		MasterKey:       DefaultMasterKey,
+		Panid:           DefaultPanid,
+		Channel:         DefaultChannel,
+		Speed:           1,
+		ReadOnly:        false,
+		RawMode:         false,
+		OtCliPath:       "ot-cli-ftd",
+		Real:            false,
+		VirtualTimeUART: false,
 	}
 }


### PR DESCRIPTION
This PR will enhance OTNS to support both virtual time UART and non-virtual time UART. 

- OTNS turns on/off virtual time UART if OS env `VIRTUAL_TIME_UART=1/0`
- Use longer `go` durations for non virtual-time UART to reduce the chance of false fails.
- Run each test for both `VIRTUAL_TIME_UART=1/0`