### PR TITLE
[test] allow to specify OT directory in test

### DIFF
--- a/script/test
+++ b/script/test
@@ -29,7 +29,7 @@
 
 set -e
 
-OT_DIR=$HOME/src/openthread
+OT_DIR=${OT_DIR:-$HOME/src/openthread}
 if [[ $(uname) == "Darwin" ]]; then
   OTBIN_DIR=$OT_DIR/output/x86_64-apple-darwin/bin
 else


### PR DESCRIPTION
**Get OTNS better suited for [#4847](https://github.com/openthread/openthread/pull/4847)**

This PR allow test script to test with a given OpenThread directory so that we can run the test script for OpenThread CI. 