### PR TITLE
[examples] add `farm` example

### DIFF
--- a/pylibs/examples/farm.py
+++ b/pylibs/examples/farm.py
@@ -26,24 +26,32 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 # This script simulates a farm in in which sensors are installed on horses.
-# See also: https://www.threadgroup.org/Farm-Jenny
+# 6 Routers are installed at the borders of the farm which has a transmission range of 300m.
+# One of the Routers is specifieid as the Gateway.
+# An SED sensor is installed on each horse to collect and transmit information to the Gateway.
+# The horses moves randomly in the farm, thus SED sensors lose connectivity to their parents constantly
+# and reattaches to new parents in range.
+# This example shows that SED devices can handle parent loss gracefully to retain connectivity.
+# The messages dropped due to parent connectivity loss can also be observed in the simulation.
+#
+# See also: https://www.threadgroup.org/Farm-Jennys
 
 import math
 import random
 
 from otns.cli import OTNS
 
+R = 6
+RECEIVER_RADIO_RANGE = 300 * R
+HORSE_RADIO_RANGE = 80 * R
+HORSE_NUM = 10
+FARM_RECT = [10 * R, 10 * R, 210 * R, 110 * R]
+
+
 def main():
     ns = OTNS(otns_args=['-log', 'info'])
     ns.speed = 1
-
     ns.web()
-
-    R = 6
-    RECEIVER_RADIO_RANGE = 300 * R
-    HORSE_RADIO_RANGE = 80 * R
-    HORSE_NUM = 10
-    FARM_RECT = [10 * R, 10 * R, 210 * R, 110 * R]
 
     gateway = ns.add("router", FARM_RECT[0], FARM_RECT[1], radio_range=RECEIVER_RADIO_RANGE)
     ns.add("router", FARM_RECT[0], FARM_RECT[3], radio_range=RECEIVER_RADIO_RANGE)
@@ -62,7 +70,6 @@ def main():
         horse_pos[sid] = (rx, ry)
         horse_move_dir[sid] = random.uniform(0, math.pi * 2)
 
-
     def blocked(sid, x, y):
         if not (FARM_RECT[0] + 20 < x < FARM_RECT[2] - 20) or not (FARM_RECT[1] + 20 < y < FARM_RECT[3] - 20):
             return True
@@ -76,7 +83,6 @@ def main():
                 return True
 
         return False
-
 
     time_accum = 0
     while True:

--- a/pylibs/examples/farm.py
+++ b/pylibs/examples/farm.py
@@ -26,6 +26,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 # This script simulates a farm in in which sensors are installed on horses.
+# See also: https://www.threadgroup.org/Farm-Jenny
+
 import math
 import random
 

--- a/pylibs/examples/farm.py
+++ b/pylibs/examples/farm.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020, The OTNS Authors.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the
+#    names of its contributors may be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# This script simulates a farm in in which sensors are installed on horses.
+import math
+import random
+
+from otns.cli import OTNS
+
+ns = OTNS(otns_args=['-log', 'info'])
+ns.speed = 1
+
+ns.web()
+
+R = 6
+RECEIVER_RADIO_RANGE = 300 * R
+HORSE_RADIO_RANGE = 80 * R
+HORSE_NUM = 10
+FARM_RECT = [10 * R, 10 * R, 210 * R, 110 * R]
+
+gateway = ns.add("router", FARM_RECT[0], FARM_RECT[1], radio_range=RECEIVER_RADIO_RANGE)
+ns.add("router", FARM_RECT[0], FARM_RECT[3], radio_range=RECEIVER_RADIO_RANGE)
+ns.add("router", FARM_RECT[2], FARM_RECT[1], radio_range=RECEIVER_RADIO_RANGE)
+ns.add("router", FARM_RECT[2], FARM_RECT[3], radio_range=RECEIVER_RADIO_RANGE)
+ns.add("router", (FARM_RECT[0] + FARM_RECT[2]) // 2, FARM_RECT[1], radio_range=RECEIVER_RADIO_RANGE)
+ns.add("router", (FARM_RECT[0] + FARM_RECT[2]) // 2, FARM_RECT[3], radio_range=RECEIVER_RADIO_RANGE)
+
+horse_pos = {}
+horse_move_dir = {}
+
+for i in range(HORSE_NUM):
+    rx = random.randint(FARM_RECT[0] + 20, FARM_RECT[2] - 20)
+    ry = random.randint(FARM_RECT[1] + 20, FARM_RECT[3] - 20)
+    sid = ns.add("sed", rx, ry, radio_range=HORSE_RADIO_RANGE)
+    horse_pos[sid] = (rx, ry)
+    horse_move_dir[sid] = random.uniform(0, math.pi * 2)
+
+
+def blocked(sid, x, y):
+    if not (FARM_RECT[0] + 20 < x < FARM_RECT[2] - 20) or not (FARM_RECT[1] + 20 < y < FARM_RECT[3] - 20):
+        return True
+
+    for oid, (ox, oy) in horse_pos.items():
+        if oid == sid:
+            continue
+
+        dist2 = (x - ox) ** 2 + (y - oy) ** 2
+        if dist2 <= 1600:
+            return True
+
+    return False
+
+
+time_accum = 0
+while True:
+    dt = 1
+    ns.go(dt)
+    time_accum += dt
+
+    for sid, (sx, sy) in horse_pos.items():
+
+        for i in range(10):
+            mdist = random.uniform(0, 2 * R * dt)
+
+            sx = int(sx + mdist * math.cos(horse_move_dir[sid]))
+            sy = int(sy + mdist * math.sin(horse_move_dir[sid]))
+
+            if blocked(sid, sx, sy):
+                horse_move_dir[sid] += random.uniform(0, math.pi * 2)
+                continue
+
+            sx = min(max(sx, FARM_RECT[0]), FARM_RECT[2])
+            sy = min(max(sy, FARM_RECT[1]), FARM_RECT[3])
+            ns.move(sid, sx, sy)
+
+            horse_pos[sid] = (sx, sy)
+            break
+
+    if time_accum >= 10:
+        for sid in horse_pos:
+            ns.ping(sid, gateway)
+        time_accum -= 10

--- a/pylibs/examples/farm.py
+++ b/pylibs/examples/farm.py
@@ -25,16 +25,16 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# This script simulates a farm in in which sensors are installed on horses.
+# This script simulates a farm where sensors are installed on horses.
 # 6 Routers are installed at the borders of the farm which has a transmission range of 300m.
-# One of the Routers is specifieid as the Gateway.
-# An SED sensor is installed on each horse to collect and transmit information to the Gateway.
+# One of the Routers is selected as the Gateway.
+# A SED sensor is installed on each horse to collect and transmit information to the Gateway.
 # The horses moves randomly in the farm, thus SED sensors lose connectivity to their parents constantly
 # and reattaches to new parents in range.
 # This example shows that SED devices can handle parent loss gracefully to retain connectivity.
 # The messages dropped due to parent connectivity loss can also be observed in the simulation.
 #
-# See also: https://www.threadgroup.org/Farm-Jennys
+# Inspired by https://www.threadgroup.org/Farm-Jenny
 
 import math
 import random


### PR DESCRIPTION
This PR adds the farm example that simulates a farm of horses, which moves and are monitored by sensors.

Run demo quickly:
```bash
cd /path/to/directory/of/ot-cli-ftd
wget https://raw.githubusercontent.com/simonlingoogle/ot-ns/demo/farm/pylibs/examples/farm.py
PYTHONPATH=/path/to/otns/pylibs python3 farm.py
```