### PR TITLE
[simulation] fix deleting node could block forever

### DIFF
--- a/otns_main/otns_main.go
+++ b/otns_main/otns_main.go
@@ -148,7 +148,7 @@ func Main(visualizerCreator func(ctx *progctx.ProgCtx, args *MainArgs) visualize
 func handleSignals(ctx *progctx.ProgCtx) {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGINT, syscall.SIGHUP)
-	signal.Ignore(syscall.SIGALRM, syscall.SIGCHLD)
+	signal.Ignore(syscall.SIGALRM)
 
 	ctx.WaitAdd("handleSignals", 1)
 	go func() {

--- a/pylibs/unittests/test_basic.py
+++ b/pylibs/unittests/test_basic.py
@@ -80,6 +80,19 @@ class BasicTests(OTNSTestCase):
         ns.go(10)
         self.assertTrue(len(ns.nodes()) == 1 and 1 not in ns.nodes())
 
+    def testDelManyNodes(self):
+        ns = self.ns
+        many = 32
+        for i in range(many):
+            ns.add("router", x=(i % 6) * 100, y=(i // 6) * 150)
+
+        ns.go(10)
+        for i in range(1, many + 1):
+            ns.delete(i)
+            ns.go(5)
+
+        self.assertTrue(ns.nodes() == {})
+
     def testMDREffective(self):
         ns = self.ns
         ns.packet_loss_ratio = 1

--- a/pylibs/unittests/test_signals.py
+++ b/pylibs/unittests/test_signals.py
@@ -32,8 +32,8 @@ import time
 import unittest
 from subprocess import TimeoutExpired
 
-from otns.cli.errors import OTNSCliEOFError
 from OTNSTestCase import OTNSTestCase
+from otns.cli.errors import OTNSCliEOFError
 
 
 class SignalsTest(OTNSTestCase):
@@ -58,9 +58,6 @@ class SignalsTest(OTNSTestCase):
 
     def testSIGALRM(self):
         self._test_signal_ignore(signal.SIGALRM)
-
-    def testSIGCHLD(self):
-        self._test_signal_ignore(signal.SIGCHLD)
 
     def _test_signal_ignore(self, sig: int):
         t = threading.Thread(target=self._send_signal, args=(1, sig))


### PR DESCRIPTION
Ignoring `SIGCHLD` could cause deleting node to block forever on macOS.

#21 has been created to catch bugs on macOS in the future. 