### PR TITLE
[visualization] configure visualization options

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -97,6 +97,7 @@ uni=on
 ack=on
 rtb=on
 ctb=on
+Done
 ```
 
 ### del \<node-id\> \[<node-id> ...\]

--- a/cli/README.md
+++ b/cli/README.md
@@ -9,6 +9,7 @@ Python libraries use the CLI to manage simulations.
 
 * [add](#add-type-x-x-y-y-rr-radio-range)
 * [counters](#counters)
+* [cv](#cv-option-onoff-)
 * [del](#del-node-id-node-id-)
 * [exit](#exit)
 * [go](#go-duration-seconds--ever)
@@ -62,6 +63,40 @@ DispatchByShortAddrSucc                  188
 DispatchByShortAddrFail                  0
 DispatchAllInRange                       0
 Done
+```
+
+### cv \[\<option\> on|off\] ...
+
+Configure visualization options.
+
+Visualization Options:
+- bro: broadcast message
+- uni: unicast message
+- ack: ACK message
+- rtb: router table
+- ctb: child table
+
+```bash
+> cv
+bro=on
+uni=on
+ack=off
+rtb=on
+ctb=on
+Done
+> cv bro off
+bro=off
+uni=on
+ack=off
+rtb=on
+ctb=on
+Done
+> cv bro on uni on ack on rtb on ctb on
+bro=on
+uni=on
+ack=on
+rtb=on
+ctb=on
 ```
 
 ### del \<node-id\> \[<node-id> ...\]

--- a/cli/ast.go
+++ b/cli/ast.go
@@ -36,26 +36,27 @@ import (
 
 //noinspection GoStructTag
 type Command struct {
-	Add        *AddCmd        `  @@` //nolint
-	CountDown  *CountDownCmd  `| @@` //nolint
-	Counters   *CountersCmd   `| @@` //nolint
-	Debug      *DebugCmd      `| @@` //nolint
-	Del        *DelCmd        `| @@` //nolint
-	DemoLegend *DemoLegendCmd `| @@` //nolint
-	Exit       *ExitCmd       `| @@` //nolint
-	Go         *GoCmd         `| @@` //nolint
-	Joins      *JoinsCmd      `| @@` //nolint
-	Move       *Move          `| @@` //nolint
-	Node       *NodeCmd       `| @@` //nolint
-	Nodes      *NodesCmd      `| @@` //nolint
-	Partitions *PartitionsCmd `| @@` //nolint
-	Ping       *PingCmd       `| @@` //nolint
-	Pings      *PingsCmd      `| @@` //nolint
-	Plr        *PlrCmd        `| @@` //nolint
-	Radio      *RadioCmd      `| @@` //nolint
-	Scan       *ScanCmd       `| @@` //nolint
-	Speed      *SpeedCmd      `| @@` //nolint
-	Web        *WebCmd        `| @@` //nolint
+	Add                 *AddCmd                 `  @@` //nolint
+	ConfigVisualization *ConfigVisualizationCmd `| @@` //nolint
+	CountDown           *CountDownCmd           `| @@` //nolint
+	Counters            *CountersCmd            `| @@` //nolint
+	Debug               *DebugCmd               `| @@` //nolint
+	Del                 *DelCmd                 `| @@` //nolint
+	DemoLegend          *DemoLegendCmd          `| @@` //nolint
+	Exit                *ExitCmd                `| @@` //nolint
+	Go                  *GoCmd                  `| @@` //nolint
+	Joins               *JoinsCmd               `| @@` //nolint
+	Move                *Move                   `| @@` //nolint
+	Node                *NodeCmd                `| @@` //nolint
+	Nodes               *NodesCmd               `| @@` //nolint
+	Partitions          *PartitionsCmd          `| @@` //nolint
+	Ping                *PingCmd                `| @@` //nolint
+	Pings               *PingsCmd               `| @@` //nolint
+	Plr                 *PlrCmd                 `| @@` //nolint
+	Radio               *RadioCmd               `| @@` //nolint
+	Scan                *ScanCmd                `| @@` //nolint
+	Speed               *SpeedCmd               `| @@` //nolint
+	Web                 *WebCmd                 `| @@` //nolint
 }
 
 //noinspection GoStructTag
@@ -168,6 +169,46 @@ type DemoLegendCmd struct {
 }
 
 //noinspection GoStructTag
+type ConfigVisualizationCmd struct {
+	Cmd              struct{}            `"cv"`    //nolint
+	BroadcastMessage *CVBroadcastMessage `( @@`    //nolint
+	UnicastMessage   *CVUnicastMessage   `| @@`    //nolint
+	AckMessage       *CVAckMessage       `| @@`    //nolint
+	RouterTable      *CVRouterTable      `| @@`    //nolint
+	ChildTable       *CVChildTable       `| @@ )*` //nolint
+}
+
+//noinspection GoStructTag
+type CVBroadcastMessage struct {
+	Flag    struct{}    `"bro"` //nolint
+	OnOrOff OnOrOffFlag `@@`    //nolint
+}
+
+//noinspection GoStructTag
+type CVUnicastMessage struct {
+	Flag    struct{}    `"uni"` //nolint
+	OnOrOff OnOrOffFlag `@@`    //nolint
+}
+
+//noinspection GoStructTag
+type CVAckMessage struct {
+	Flag    struct{}    `"ack"` //nolint
+	OnOrOff OnOrOffFlag `@@`    //nolint
+}
+
+//noinspection GoStructTag
+type CVRouterTable struct {
+	Flag    struct{}    `"rtb"` //nolint
+	OnOrOff OnOrOffFlag `@@`    //nolint
+}
+
+//noinspection GoStructTag
+type CVChildTable struct {
+	Flag    struct{}    `"ctb"` //nolint
+	OnOrOff OnOrOffFlag `@@`    //nolint
+}
+
+//noinspection GoStructTag
 type CountDownCmd struct {
 	Cmd     struct{} `"countdown"` //nolint
 	Seconds int      `@Int`        //nolint
@@ -260,6 +301,12 @@ type OnFlag struct {
 //noinspection GoStructTag
 type OffFlag struct {
 	Dummy struct{} `"off"` //nolint
+}
+
+//noinspection GoStructTag
+type OnOrOffFlag struct {
+	On  *OnFlag  `( @@`   //nolint
+	Off *OffFlag `| @@ )` //nolint
 }
 
 //noinspection GoStructTag

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -108,6 +108,7 @@ type Dispatcher struct {
 	rloc16Map             rloc16Map
 	goDurationChan        chan goDuration
 	globalPacketLossRatio float64
+	visOptions            VisualizationOptions
 
 	Counters struct {
 		// Event counters
@@ -158,6 +159,7 @@ func NewDispatcher(ctx *progctx.ProgCtx, cfg *Config, cbHandler CallbackHandler)
 		taskChan:           make(chan func(), 100),
 		watchingNodes:      map[NodeId]struct{}{},
 		goDurationChan:     make(chan goDuration, 10),
+		visOptions:         defaultVisualizationOptions(),
 	}
 	d.speed = d.normalizeSpeed(d.speed)
 	d.pcap, err = pcap.NewFile("current.pcap")
@@ -994,4 +996,13 @@ func (d *Dispatcher) onStatusPushExtAddr(node *Node, oldExtAddr uint64) {
 
 	d.extaddrMap[node.ExtAddr] = node
 	d.vis.OnExtAddrChange(node.Id, node.ExtAddr)
+}
+
+func (d *Dispatcher) GetVisualizationOptions() VisualizationOptions {
+	return d.visOptions
+}
+
+func (d *Dispatcher) SetVisualizationOptions(opts VisualizationOptions) {
+	simplelogger.Debugf("dispatcher set visualization options: %+v", opts)
+	d.visOptions = opts
 }

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -750,19 +750,27 @@ func (d *Dispatcher) handleStatusPush(srcid NodeId, data string) {
 		} else if sp[0] == "router_added" {
 			extaddr, err := strconv.ParseUint(sp[1], 16, 64)
 			simplelogger.PanicIfError(err)
-			d.vis.AddRouterTable(srcid, extaddr)
+			if d.visOptions.RouterTable {
+				d.vis.AddRouterTable(srcid, extaddr)
+			}
 		} else if sp[0] == "router_removed" {
 			extaddr, err := strconv.ParseUint(sp[1], 16, 64)
 			simplelogger.PanicIfError(err)
-			d.vis.RemoveRouterTable(srcid, extaddr)
+			if d.visOptions.RouterTable {
+				d.vis.RemoveRouterTable(srcid, extaddr)
+			}
 		} else if sp[0] == "child_added" {
 			extaddr, err := strconv.ParseUint(sp[1], 16, 64)
 			simplelogger.PanicIfError(err)
-			d.vis.AddChildTable(srcid, extaddr)
+			if d.visOptions.ChildTable {
+				d.vis.AddChildTable(srcid, extaddr)
+			}
 		} else if sp[0] == "child_removed" {
 			extaddr, err := strconv.ParseUint(sp[1], 16, 64)
 			simplelogger.PanicIfError(err)
-			d.vis.RemoveChildTable(srcid, extaddr)
+			if d.visOptions.ChildTable {
+				d.vis.RemoveChildTable(srcid, extaddr)
+			}
 		} else if sp[0] == "parent" {
 			extaddr, err := strconv.ParseUint(sp[1], 16, 64)
 			simplelogger.PanicIfError(err)

--- a/dispatcher/visualization_options.go
+++ b/dispatcher/visualization_options.go
@@ -12,7 +12,7 @@ func defaultVisualizationOptions() VisualizationOptions {
 	return VisualizationOptions{
 		BroadcastMessage: true,
 		UnicastMessage:   true,
-		AckMessage:       true,
+		AckMessage:       false,
 		RouterTable:      true,
 		ChildTable:       true,
 	}

--- a/dispatcher/visualization_options.go
+++ b/dispatcher/visualization_options.go
@@ -1,0 +1,19 @@
+package dispatcher
+
+type VisualizationOptions struct {
+	BroadcastMessage bool
+	UnicastMessage   bool
+	AckMessage       bool
+	RouterTable      bool
+	ChildTable       bool
+}
+
+func defaultVisualizationOptions() VisualizationOptions {
+	return VisualizationOptions{
+		BroadcastMessage: true,
+		UnicastMessage:   true,
+		AckMessage:       true,
+		RouterTable:      true,
+		ChildTable:       true,
+	}
+}

--- a/dispatcher/visualization_options.go
+++ b/dispatcher/visualization_options.go
@@ -1,3 +1,29 @@
+// Copyright (c) 2020, The OTNS Authors.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the
+//    names of its contributors may be used to endorse or promote products
+//    derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 package dispatcher
 
 type VisualizationOptions struct {

--- a/pylibs/examples/farm.py
+++ b/pylibs/examples/farm.py
@@ -51,6 +51,7 @@ FARM_RECT = [10 * R, 10 * R, 210 * R, 110 * R]
 def main():
     ns = OTNS(otns_args=['-log', 'info'])
     ns.speed = 1
+    ns.config_visualization(broadcast_message=False)
     ns.web()
 
     gateway = ns.add("router", FARM_RECT[0], FARM_RECT[1], radio_range=RECEIVER_RADIO_RANGE)

--- a/pylibs/otns/cli/OTNS.py
+++ b/pylibs/otns/cli/OTNS.py
@@ -539,6 +539,20 @@ class OTNS(object):
         timeout_s = f" {timeout}" if timeout is not None else ""
         self.node_cmd(nodeid, f"commissioner joiner add {usr} {pwd}{timeout_s}")
 
+    def config_visualization(self, broadcast_message: bool = None, unicast_message: bool = None,
+                             ack_message: bool = None, router_table: bool = None, child_table: bool = None) \
+            -> Dict[str, bool]:
+        """
+        Configure the visualization options.
+
+        :param broadcast_messages: whether or not to visualize broadcast messages
+        :param unicast_messages: whether or not to visualize unicast messages
+        :param ack_messages: whether or not to visualize ACK messages
+        :param router_table: whether or not to visualize router tables
+        :param child_table: whether or not to visualize child tables
+        """
+        pass
+
     @staticmethod
     def _expect_int(output: List[str]) -> int:
         assert len(output) == 1, output

--- a/pylibs/otns/cli/OTNS.py
+++ b/pylibs/otns/cli/OTNS.py
@@ -545,13 +545,43 @@ class OTNS(object):
         """
         Configure the visualization options.
 
-        :param broadcast_messages: whether or not to visualize broadcast messages
-        :param unicast_messages: whether or not to visualize unicast messages
-        :param ack_messages: whether or not to visualize ACK messages
+        :param broadcast_message: whether or not to visualize broadcast messages
+        :param unicast_message: whether or not to visualize unicast messages
+        :param ack_message: whether or not to visualize ACK messages
         :param router_table: whether or not to visualize router tables
         :param child_table: whether or not to visualize child tables
         """
-        pass
+        cmd = "cv"
+        if broadcast_message is not None:
+            cmd += " bro " + ("on" if broadcast_message else "off")
+
+        if unicast_message is not None:
+            cmd += " uni " + ("on" if unicast_message else "off")
+
+        if ack_message is not None:
+            cmd += " ack " + ("on" if ack_message else "off")
+
+        if router_table is not None:
+            cmd += " rtb " + ("on" if router_table else "off")
+
+        if child_table is not None:
+            cmd += " ctb " + ("on" if child_table else "off")
+
+        output = self._do_command(cmd)
+        vopts = {}
+        for line in output:
+            line = line.split('=')
+            assert len(line) == 2 and line[1] in ('on', 'off'), line
+            vopts[line[0]] = (line[1] == "on")
+
+        # convert command options to python options
+        vopts['broadcast_message'] = vopts.pop('bro')
+        vopts['unicast_message'] = vopts.pop('uni')
+        vopts['ack_message'] = vopts.pop('ack')
+        vopts['router_table'] = vopts.pop('rtb')
+        vopts['child_table'] = vopts.pop('ctb')
+
+        return vopts
 
     @staticmethod
     def _expect_int(output: List[str]) -> int:

--- a/pylibs/otns/cli/OTNS.py
+++ b/pylibs/otns/cli/OTNS.py
@@ -550,6 +550,8 @@ class OTNS(object):
         :param ack_message: whether or not to visualize ACK messages
         :param router_table: whether or not to visualize router tables
         :param child_table: whether or not to visualize child tables
+
+        :return: the active visualization options
         """
         cmd = "cv"
         if broadcast_message is not None:

--- a/pylibs/unittests/test_basic.py
+++ b/pylibs/unittests/test_basic.py
@@ -185,7 +185,7 @@ class BasicTests(OTNSTestCase):
         vopts = ns.config_visualization()
         print('vopts', vopts)
         for opt in ('broadcast_message', 'unicast_message', 'ack_message', 'router_table', 'child_table'):
-            self.assertTrue(vopts[opt])
+            self.assertTrue(opt in vopts)
 
         vopts = ns.config_visualization(broadcast_message=False)
         self.assertFalse(vopts['broadcast_message'])

--- a/pylibs/unittests/test_basic.py
+++ b/pylibs/unittests/test_basic.py
@@ -180,6 +180,38 @@ class BasicTests(OTNSTestCase):
         c20 = ns.counters()
         assert_increasing(c10, c20)
 
+    def testConfigVisualization(self):
+        ns = self.ns
+        vopts = ns.config_visualization()
+        print('vopts', vopts)
+        for opt in ('broadcast_message', 'unicast_message', 'ack_message', 'router_table', 'child_table'):
+            self.assertTrue(vopts[opt])
+
+        vopts = ns.config_visualization(broadcast_message=False)
+        self.assertFalse(vopts['broadcast_message'])
+
+        vopts = ns.config_visualization(unicast_message=False)
+        self.assertFalse(vopts['broadcast_message'])
+        self.assertFalse(vopts['unicast_message'])
+
+        vopts = ns.config_visualization(ack_message=False)
+        self.assertFalse(vopts['ack_message'])
+        vopts = ns.config_visualization(ack_message=True)
+        self.assertTrue(vopts['ack_message'])
+
+        vopts = ns.config_visualization(router_table=False)
+        self.assertFalse(vopts['router_table'])
+
+        vopts = ns.config_visualization(child_table=False)
+        self.assertFalse(vopts['child_table'])
+
+        vopts = ns.config_visualization(broadcast_message=True, unicast_message=True, ack_message=True,
+                                        router_table=True,
+                                        child_table=True)
+
+        for opt in ('broadcast_message', 'unicast_message', 'ack_message', 'router_table', 'child_table'):
+            self.assertTrue(vopts[opt])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pylibs/unittests/test_basic.py
+++ b/pylibs/unittests/test_basic.py
@@ -187,23 +187,10 @@ class BasicTests(OTNSTestCase):
         for opt in ('broadcast_message', 'unicast_message', 'ack_message', 'router_table', 'child_table'):
             self.assertTrue(opt in vopts)
 
-        vopts = ns.config_visualization(broadcast_message=False)
-        self.assertFalse(vopts['broadcast_message'])
-
-        vopts = ns.config_visualization(unicast_message=False)
-        self.assertFalse(vopts['broadcast_message'])
-        self.assertFalse(vopts['unicast_message'])
-
-        vopts = ns.config_visualization(ack_message=False)
-        self.assertFalse(vopts['ack_message'])
-        vopts = ns.config_visualization(ack_message=True)
-        self.assertTrue(vopts['ack_message'])
-
-        vopts = ns.config_visualization(router_table=False)
-        self.assertFalse(vopts['router_table'])
-
-        vopts = ns.config_visualization(child_table=False)
-        self.assertFalse(vopts['child_table'])
+            set_vals = (False, True) if vopts[opt] else (True, False)
+            for v in set_vals:
+                vopts[opt] = v
+                self.assertTrue(ns.config_visualization(**{opt: v}) == vopts)
 
         vopts = ns.config_visualization(broadcast_message=True, unicast_message=True, ack_message=True,
                                         router_table=True,
@@ -211,6 +198,13 @@ class BasicTests(OTNSTestCase):
 
         for opt in ('broadcast_message', 'unicast_message', 'ack_message', 'router_table', 'child_table'):
             self.assertTrue(vopts[opt])
+
+        vopts = ns.config_visualization(broadcast_message=False, unicast_message=False, ack_message=False,
+                                        router_table=False,
+                                        child_table=False)
+
+        for opt in ('broadcast_message', 'unicast_message', 'ack_message', 'router_table', 'child_table'):
+            self.assertFalse(vopts[opt])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR:
- Add the `cv` command for configuring visualization options
- Add `OTNS.config_visualization` to `pyOTNS`
- Turn off visualization broadcast messages  in the `farm` demo 