### PR TITLE
[signals] make sure otns gracefully when terminated

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,3 +87,23 @@ jobs:
       - name: Run Examples
         run: |
           ./script/test py-examples
+
+  signals:
+    name: Signals (Py${{ matrix.python-version }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.6]
+        os: [ubuntu-latest, macos-10.15]
+    steps:
+      - uses: actions/setup-go@v1
+        with:
+          go-version: 1.11
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/checkout@v2
+      - name: Test
+        run: |
+          ./script/test signals

--- a/cli/CmdRunner.go
+++ b/cli/CmdRunner.go
@@ -185,7 +185,6 @@ func (rt *CmdRunner) postAsyncWait(f func(sim *simulation.Simulation)) {
 		f(rt.sim)
 		close(done)
 	})
-
 	<-done
 }
 

--- a/cli/CmdRunner.go
+++ b/cli/CmdRunner.go
@@ -185,6 +185,7 @@ func (rt *CmdRunner) postAsyncWait(f func(sim *simulation.Simulation)) {
 		f(rt.sim)
 		close(done)
 	})
+
 	<-done
 }
 

--- a/cli/runner.go
+++ b/cli/runner.go
@@ -65,10 +65,7 @@ func enterNodeContext(nodeid NodeId) bool {
 }
 
 func Run(cr *CmdRunner) error {
-	ctx := cr.ctx
-
-	ctx.WaitAdd("cli", 1)
-	defer ctx.WaitDone("cli")
+	defer simplelogger.Debugf("CLI exit")
 
 	stdinFd := int(os.Stdin.Fd())
 	stdinIsTerminal := readline.IsTerminal(stdinFd)

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -659,7 +659,7 @@ func (d *Dispatcher) setSleeping(nodeid NodeId) {
 }
 
 func (d *Dispatcher) syncAliveNodes() {
-	if len(d.aliveNodes) == 0 || d.ctx.Err() != nil {
+	if len(d.aliveNodes) == 0 {
 		return
 	}
 

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -320,7 +320,6 @@ func (d *Dispatcher) handleRecvEvent(evt *event) {
 func (d *Dispatcher) recvEvents() int {
 	blockTimeout := time.After(time.Second * 5)
 	count := 0
-	progExit := d.ctx.Done()
 
 loop:
 	for {
@@ -333,9 +332,6 @@ loop:
 				d.handleRecvEvent(evt)
 			case <-blockTimeout:
 				// timeout
-				break loop
-			case <-progExit:
-				// program exit
 				break loop
 			}
 		} else {

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -201,9 +201,6 @@ func (d *Dispatcher) Run() {
 	d.ctx.WaitAdd("dispatcher", 1)
 	defer d.ctx.WaitDone("dispatcher")
 	defer simplelogger.Debugf("dispatcher exit.")
-	d.ctx.Defer(func() {
-		_ = d.udpln.Close()
-	})
 
 	defer d.Stop()
 

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -200,7 +200,7 @@ func (d *Dispatcher) Go(duration time.Duration) <-chan struct{} {
 func (d *Dispatcher) Run() {
 	d.ctx.WaitAdd("dispatcher", 1)
 	defer d.ctx.WaitDone("dispatcher")
-	defer simplelogger.Infof("dispatcher exit.")
+	defer simplelogger.Debugf("dispatcher exit.")
 	d.ctx.Defer(func() {
 		_ = d.udpln.Close()
 	})
@@ -320,6 +320,7 @@ func (d *Dispatcher) handleRecvEvent(evt *event) {
 func (d *Dispatcher) recvEvents() int {
 	blockTimeout := time.After(time.Second * 5)
 	count := 0
+	progExit := d.ctx.Done()
 
 loop:
 	for {
@@ -332,6 +333,9 @@ loop:
 				d.handleRecvEvent(evt)
 			case <-blockTimeout:
 				// timeout
+				break loop
+			case <-progExit:
+				// program exit
 				break loop
 			}
 		} else {
@@ -655,7 +659,7 @@ func (d *Dispatcher) setSleeping(nodeid NodeId) {
 }
 
 func (d *Dispatcher) syncAliveNodes() {
-	if len(d.aliveNodes) == 0 {
+	if len(d.aliveNodes) == 0 || d.ctx.Err() != nil {
 		return
 	}
 

--- a/otns_main/otns_main.go
+++ b/otns_main/otns_main.go
@@ -95,8 +95,6 @@ func Main(visualizerCreator func(ctx *progctx.ProgCtx, args *MainArgs) visualize
 	ctx := progctx.New(context.Background())
 	ctx.Defer(func() {
 		_ = os.Stdin.Close()
-		_ = os.Stdout.Close()
-		_ = os.Stderr.Close()
 	})
 
 	handleSignals(ctx)

--- a/otns_main/otns_main.go
+++ b/otns_main/otns_main.go
@@ -95,6 +95,8 @@ func Main(visualizerCreator func(ctx *progctx.ProgCtx, args *MainArgs) visualize
 	ctx := progctx.New(context.Background())
 	ctx.Defer(func() {
 		_ = os.Stdin.Close()
+		_ = os.Stdout.Close()
+		_ = os.Stderr.Close()
 	})
 
 	handleSignals(ctx)
@@ -153,6 +155,7 @@ func handleSignals(ctx *progctx.ProgCtx) {
 	ctx.WaitAdd("handleSignals", 1)
 	go func() {
 		defer ctx.WaitDone("handleSignals")
+		defer simplelogger.Debugf("handleSignals exit.")
 
 		for {
 			select {

--- a/pylibs/otns/cli/OTNS.py
+++ b/pylibs/otns/cli/OTNS.py
@@ -28,6 +28,7 @@
 import logging
 import os
 import shutil
+import signal
 import subprocess
 from typing import List, Union, Optional, Tuple, Dict, Any, Collection
 
@@ -68,7 +69,7 @@ class OTNS(object):
 
         self._closed = True
         logging.info("waiting for OTNS to close ...")
-        self._otns.kill()
+        self._otns.send_signal(signal.SIGTERM)
         try:
             self._otns.__exit__(None, None, None)
         except BrokenPipeError:

--- a/pylibs/otns/cli/OTNS.py
+++ b/pylibs/otns/cli/OTNS.py
@@ -58,7 +58,7 @@ class OTNS(object):
                                       stdout=subprocess.PIPE)
         logging.info("otns process launched: %s", self._otns)
 
-    def close(self, timeout=None) -> None:
+    def close(self) -> None:
         """
         Close OTNS simulation.
 

--- a/pylibs/otns/cli/OTNS.py
+++ b/pylibs/otns/cli/OTNS.py
@@ -47,6 +47,7 @@ class OTNS(object):
         self._otns_args = list(otns_args or []) + ['-autogo=false', '-web=false']
         logging.info("otns found: %s", self._otns_path)
         self._launch_otns()
+        self._closed = False
 
     def _launch_otns(self) -> None:
         logging.info("launching otns: %s %s", self._otns_path, ' '.join(self._otns_args))
@@ -62,13 +63,16 @@ class OTNS(object):
 
         :param timeout: timeout for waiting otns process to quit
         """
-        if self._otns.returncode is not None:
+        if self._closed:
             return
+
+        self._closed = True
         logging.info("waiting for OTNS to close ...")
-        self._otns.stdin.close()
-        self._otns.stdout.close()
         self._otns.kill()
-        self._otns.wait(timeout=timeout)
+        try:
+            self._otns.__exit__(None, None, None)
+        except BrokenPipeError:
+            pass
 
     def go(self, duration: float = None, speed: float = None) -> None:
         """

--- a/pylibs/otns/cli/OTNS.py
+++ b/pylibs/otns/cli/OTNS.py
@@ -63,8 +63,7 @@ class OTNS(object):
         :param timeout: timeout for waiting otns process to quit
         """
         logging.info("waiting for OTNS to close ...")
-        self._otns.stdin.close()
-        self._otns.stdout.close()
+        self._otns.kill()
         self._otns.wait(timeout=timeout)
 
     def go(self, duration: float = None, speed: float = None) -> None:

--- a/pylibs/otns/cli/OTNS.py
+++ b/pylibs/otns/cli/OTNS.py
@@ -63,6 +63,11 @@ class OTNS(object):
         :param timeout: timeout for waiting otns process to quit
         """
         logging.info("waiting for OTNS to close ...")
+        if self._otns.returncode is not None:
+            return
+
+        self._otns.stdin.close()
+        self._otns.stdout.close()
         self._otns.kill()
         self._otns.wait(timeout=timeout)
 

--- a/pylibs/otns/cli/OTNS.py
+++ b/pylibs/otns/cli/OTNS.py
@@ -63,11 +63,6 @@ class OTNS(object):
         :param timeout: timeout for waiting otns process to quit
         """
         logging.info("waiting for OTNS to close ...")
-        if self._otns.returncode is not None:
-            return
-
-        self._otns.stdin.close()
-        self._otns.stdout.close()
         self._otns.kill()
         self._otns.wait(timeout=timeout)
 

--- a/pylibs/otns/cli/OTNS.py
+++ b/pylibs/otns/cli/OTNS.py
@@ -62,7 +62,11 @@ class OTNS(object):
 
         :param timeout: timeout for waiting otns process to quit
         """
+        if self._otns.returncode is not None:
+            return
         logging.info("waiting for OTNS to close ...")
+        self._otns.stdin.close()
+        self._otns.stdout.close()
         self._otns.kill()
         self._otns.wait(timeout=timeout)
 

--- a/pylibs/unittests/OTNSTestCase.py
+++ b/pylibs/unittests/OTNSTestCase.py
@@ -43,7 +43,7 @@ class OTNSTestCase(unittest.TestCase):
         self.ns.speed = OTNS.MAX_SIMULATE_SPEED
 
     def tearDown(self, timeout=60) -> None:
-        self.ns.close(timeout=timeout)
+        self.ns.close(timeout)
 
     def assertFormPartitions(self, count: int):
         pars = self.ns.partitions()

--- a/pylibs/unittests/OTNSTestCase.py
+++ b/pylibs/unittests/OTNSTestCase.py
@@ -42,8 +42,8 @@ class OTNSTestCase(unittest.TestCase):
         self.ns = OTNS(otns_args=['-log', 'debug'])
         self.ns.speed = OTNS.MAX_SIMULATE_SPEED
 
-    def tearDown(self, timeout=60) -> None:
-        self.ns.close(timeout)
+    def tearDown(self) -> None:
+        self.ns.close()
 
     def assertFormPartitions(self, count: int):
         pars = self.ns.partitions()

--- a/pylibs/unittests/OTNSTestCase.py
+++ b/pylibs/unittests/OTNSTestCase.py
@@ -39,11 +39,11 @@ class OTNSTestCase(unittest.TestCase):
         logging.basicConfig(level=logging.DEBUG)
 
     def setUp(self) -> None:
-        self.ns = OTNS()
+        self.ns = OTNS(otns_args=['-log', 'debug'])
         self.ns.speed = OTNS.MAX_SIMULATE_SPEED
 
-    def tearDown(self) -> None:
-        self.ns.close()
+    def tearDown(self, timeout=60) -> None:
+        self.ns.close(timeout=timeout)
 
     def assertFormPartitions(self, count: int):
         pars = self.ns.partitions()

--- a/pylibs/unittests/test_signals.py
+++ b/pylibs/unittests/test_signals.py
@@ -57,7 +57,7 @@ class SignalsTest(OTNSTestCase):
             logging.info("round %d", i + 1)
             self._test_signal_exit(signal.SIGTERM, 0)
 
-            self.tearDown(timeout=WAIT_OTNS_TIMEOUT)
+            self.tearDown()
             self.setUp()
 
     def testSIGQUIT(self):

--- a/pylibs/unittests/test_signals.py
+++ b/pylibs/unittests/test_signals.py
@@ -60,6 +60,25 @@ class SignalsTest(OTNSTestCase):
     def testSIGALRM(self):
         self._test_signal_ignore(signal.SIGALRM)
 
+    def testCommandHandleSignalOk(self):
+        for i in range(100):
+            self._testCommandHandleSignalOk()
+
+            self.tearDown()
+            self.setUp()
+
+    def _testCommandHandleSignalOk(self):
+        t = threading.Thread(target=self._send_signal, args=(0.1, signal.SIGINT))
+        t.start()
+        self.ns.speed = float('inf')
+        try:
+            while True:
+                self.ns.add("router")
+        except OTNSExitedError as ex:
+            self.assertEqual(0, ex.exit_code)
+
+        t.join()
+
     def _test_signal_ignore(self, sig: int):
         t = threading.Thread(target=self._send_signal, args=(1, sig))
         t.start()

--- a/pylibs/unittests/test_signals.py
+++ b/pylibs/unittests/test_signals.py
@@ -51,7 +51,7 @@ class SignalsTest(OTNSTestCase):
     def testSIGTERM(self):
         self._test_signal_exit(signal.SIGTERM)
 
-    def testSIGTERMx100(self):
+    def testSIGTERMx1000(self):
         N = 1000
         for i in range(N):
             logging.info("round %d", i + 1)

--- a/pylibs/unittests/test_signals.py
+++ b/pylibs/unittests/test_signals.py
@@ -72,7 +72,7 @@ class SignalsTest(OTNSTestCase):
     def testSIGALRM(self):
         self._test_signal_ignore(signal.SIGALRM)
 
-    def testCommandHandleSignalOk(self):
+    def testCommandHandleSignalOkx100(self):
         for i in range(100):
             self._testCommandHandleSignalOk()
 

--- a/pylibs/unittests/test_signals.py
+++ b/pylibs/unittests/test_signals.py
@@ -80,10 +80,10 @@ class SignalsTest(OTNSTestCase):
             self.setUp()
 
     def _testCommandHandleSignalOk(self):
-        t = threading.Thread(target=self._send_signal, args=(0.1, signal.SIGINT))
+        t = threading.Thread(target=self._send_signal, args=(0.01, signal.SIGTERM))
         t.start()
-        self.ns.speed = float('inf')
         try:
+            self.ns.speed = float('inf')
             while True:
                 self.ns.add("router")
         except OTNSExitedError as ex:

--- a/script/test
+++ b/script/test
@@ -91,7 +91,6 @@ py_unittests() {
   python3 $OTNSDIR/pylibs/unittests/test_basic.py
   python3 $OTNSDIR/pylibs/unittests/test_ping.py
   python3 $OTNSDIR/pylibs/unittests/test_commissioning.py
-  python3 $OTNSDIR/pylibs/unittests/test_signals.py
   cd -
 }
 
@@ -116,10 +115,20 @@ py_examples() {
   cd -
 }
 
+test_signals() {
+  install_deps
+  install
+  build_openthread
+  cd $OTBIN_DIR
+  python3 $OTNSDIR/pylibs/unittests/test_signals.py
+  cd -
+}
+
 main() {
   do_go_tests=0
   do_py_unittests=0
   do_py_examples=0
+  do_signals=0
 
   for var in "$@"; do
     if [[ "$var" == "go-tests" ]]; then
@@ -128,6 +137,8 @@ main() {
       do_py_unittests=1
     elif [[ "$var" == "py-examples" ]]; then
       do_py_examples=1
+    elif [[ "$var" == "signals" ]]; then
+      do_signals=1
     fi
   done
 
@@ -141,6 +152,10 @@ main() {
 
   if [[ "$do_py_examples" == "1" ]]; then
     py_examples
+  fi
+
+  if [[ "$do_signals" == "1" ]]; then
+    test_signals
   fi
 }
 

--- a/simulation/node.go
+++ b/simulation/node.go
@@ -28,6 +28,7 @@ package simulation
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -63,7 +64,7 @@ func newNode(s *Simulation, id NodeId, cfg *NodeConfig) (*Node, error) {
 		return nil, err
 	}
 	simplelogger.Debugf("node exe path: %s", exePath)
-	cmd := exec.CommandContext(s.ctx, exePath, strconv.Itoa(id))
+	cmd := exec.CommandContext(context.Background(), exePath, strconv.Itoa(id))
 	pipeIn, err := cmd.StdinPipe()
 	if err != nil {
 		return nil, err

--- a/simulation/simulation.go
+++ b/simulation/simulation.go
@@ -116,7 +116,7 @@ func (s *Simulation) genNodeId() NodeId {
 func (s *Simulation) Run() {
 	s.ctx.WaitAdd("simulation", 1)
 	defer s.ctx.WaitDone("simulation")
-	defer simplelogger.Infof("simulation exit.")
+	defer simplelogger.Debugf("simulation exit.")
 
 	s.d.Run()
 }


### PR DESCRIPTION
This PR fixes potential blocking issues when terminated:

- [x] Fix dispatcher issue that might block for seconds when terminating
- [x] Do not wait for CLI to exit (might block, and not necessary)
- [x] Use separate GitHub job for testing signals