### PR TITLE
[go-mod] update go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,24 +29,29 @@ module github.com/openthread/ot-ns
 go 1.13
 
 require (
-	github.com/alecthomas/participle v0.3.1-0.20191020040520-729a7c1de92a
+	github.com/alecthomas/participle v0.5.0
 	github.com/chzyer/logex v1.1.10 // indirect
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect
-	github.com/golang/protobuf v1.3.5
-	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
-	github.com/pkg/errors v0.8.1
+	github.com/golang/protobuf v1.4.2
+	github.com/google/go-cmp v0.4.1 // indirect
+	github.com/kr/pretty v0.2.0 // indirect
+	github.com/kr/text v0.2.0 // indirect
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/simonlingoogle/go-simplelogger v0.0.0-20191122025812-962af3877d65
-	github.com/stretchr/testify v1.4.0
-	go.uber.org/atomic v1.5.1 // indirect
-	go.uber.org/multierr v1.4.0 // indirect
-	go.uber.org/zap v1.13.0 // indirect
-	golang.org/x/net v0.0.0-20200202094626-16171245cfb2 // indirect
-	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 // indirect
+	github.com/stretchr/testify v1.6.1
+	go.uber.org/zap v1.15.0 // indirect
+	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
+	golang.org/x/mod v0.3.0 // indirect
+	golang.org/x/net v0.0.0-20200602114024-627f9648deb9 // indirect
+	golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 // indirect
 	golang.org/x/text v0.3.2 // indirect
-	golang.org/x/tools v0.0.0-20191212051200-825cb0626375 // indirect
-	google.golang.org/genproto v0.0.0-20200212174721-66ed5ce911ce // indirect
-	google.golang.org/grpc v1.27.1
-	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
-	gopkg.in/yaml.v2 v2.2.7 // indirect
+	golang.org/x/tools v0.0.0-20200608174601-1b747fd94509 // indirect
+	google.golang.org/genproto v0.0.0-20200608115520-7c474a2e3482 // indirect
+	google.golang.org/grpc v1.29.1
+	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
+	gopkg.in/yaml.v2 v2.3.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c // indirect
+	honnef.co/go/tools v0.0.1-2020.1.4 // indirect
 )


### PR DESCRIPTION
Run: 
```bash
$ go get -u all && go mod tidy
```

Decided to update Go modules because this error happens often in GitHub actions:
```bash
go: honnef.co/go/tools@v0.0.1-2019.2.3: unknown revision v0.0.1-2019.2.3
go: error loading module requirements
```