### PR TITLE
[dispatcher] call recvEvents() when no node

### DIFF
--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -215,6 +215,7 @@ loop:
 			// sync the speed start time with the current time
 			if len(d.nodes) == 0 {
 				// no nodes, sleep for a small duration to avoid high cpu
+				d.recvEvents()
 				time.Sleep(time.Millisecond * 10)
 				close(duration.done)
 				break


### PR DESCRIPTION
This PR allows dispatcher to receive and handle UDP events even when there is no node. 

**Background:**
- Usually, OTNS creates nodes by itself and expects no UDP event before it starts creating nodes. 
- However, it is possible that user starts an OpenThread instance manually. OTNS should be able to receive UDP events from this instance too. 