### PR TITLE
[dispatcher] add real mode for real devices

### DIFF
--- a/cmd/real/otns-silk-proxy/otns-silk-proxy.go
+++ b/cmd/real/otns-silk-proxy/otns-silk-proxy.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+
+	"github.com/chzyer/readline"
+	"github.com/simonlingoogle/go-simplelogger"
+)
+
+const (
+	Prompt = "> "
+)
+
+func runCli() error {
+	stdinFd := int(os.Stdin.Fd())
+	stdinIsTerminal := readline.IsTerminal(stdinFd)
+	if stdinIsTerminal {
+		stdinState, err := readline.GetState(stdinFd)
+		if err != nil {
+			return err
+		}
+
+		defer func() {
+			_ = readline.Restore(stdinFd, stdinState)
+		}()
+	}
+
+	stdoutFd := int(os.Stdout.Fd())
+	stdoutIsTerminal := readline.IsTerminal(stdoutFd)
+	if stdoutIsTerminal {
+		stdoutState, err := readline.GetState(stdoutFd)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			_ = readline.Restore(stdoutFd, stdoutState)
+		}()
+	}
+
+	l, err := readline.NewEx(&readline.Config{
+		Prompt:          Prompt,
+		InterruptPrompt: "^C",
+		EOFPrompt:       "exit",
+
+		HistorySearchFold: true,
+		FuncFilterInputRune: func(r rune) (rune, bool) {
+			switch r {
+			// block CtrlZ feature
+			case readline.CharCtrlZ:
+				return r, false
+			}
+			return r, true
+		},
+	})
+
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = l.Close()
+	}()
+
+	for {
+		line, err := l.Readline()
+
+		if err == readline.ErrInterrupt {
+			if len(line) == 0 {
+				return nil
+			} else {
+				continue
+			}
+		} else if err == io.EOF {
+			return nil
+		} else if err != nil {
+			return err
+		}
+
+		_, _ = os.Stdout.WriteString(line + "\n")
+
+		cmd := strings.TrimSpace(line)
+		if len(cmd) == 0 {
+			continue
+		}
+
+		// just output Done for all commands because the silk proxy does not manage the devices
+		_, _ = os.Stdout.WriteString("Done\n")
+
+		if cmd == "exit" {
+			os.Exit(0)
+		}
+
+		_ = os.Stdout.Sync()
+	}
+}
+
+func main() {
+	err := runCli()
+	if err != nil {
+		simplelogger.Error(err)
+	}
+}

--- a/otns_main/otns_main.go
+++ b/otns_main/otns_main.go
@@ -59,14 +59,14 @@ import (
 )
 
 type MainArgs struct {
-	Speed    string
+	Speed     string
 	OtCliPath string
-	AutoGo   bool
-	ReadOnly bool
-	LogLevel string
-	OpenWeb  bool
-	RawMode  bool
-	Real     bool
+	AutoGo    bool
+	ReadOnly  bool
+	LogLevel  string
+	OpenWeb   bool
+	RawMode   bool
+	Real      bool
 }
 
 var (

--- a/otns_main/otns_main.go
+++ b/otns_main/otns_main.go
@@ -59,13 +59,14 @@ import (
 )
 
 type MainArgs struct {
-	Speed     string
+	Speed    string
 	OtCliPath string
-	AutoGo    bool
-	ReadOnly  bool
-	LogLevel  string
-	OpenWeb   bool
-	RawMode   bool
+	AutoGo   bool
+	ReadOnly bool
+	LogLevel string
+	OpenWeb  bool
+	RawMode  bool
+	Real     bool
 }
 
 var (
@@ -80,6 +81,7 @@ func parseArgs() {
 	flag.StringVar(&args.LogLevel, "log", "warn", "set logging level")
 	flag.BoolVar(&args.OpenWeb, "web", true, "open web")
 	flag.BoolVar(&args.RawMode, "raw", false, "use raw mode")
+	flag.BoolVar(&args.Real, "real", false, "use real mode (for real devices)")
 
 	flag.Parse()
 	flag.Args()
@@ -190,6 +192,7 @@ func createSimulation(ctx *progctx.ProgCtx) *simulation.Simulation {
 	simcfg.Speed = speed
 	simcfg.ReadOnly = args.ReadOnly
 	simcfg.RawMode = args.RawMode
+	simcfg.Real = args.Real
 
 	sim, err := simulation.NewSimulation(ctx, simcfg)
 	simplelogger.FatalIfError(err)

--- a/script/install
+++ b/script/install
@@ -33,6 +33,7 @@
 install_otns()
 {
     repeat 3 go get ./cmd/otns
+    repeat 3 go get ./cmd/real/...
     echo "otns installed: $(command -v otns)"
 }
 

--- a/simulation/node.go
+++ b/simulation/node.go
@@ -97,6 +97,7 @@ func newNode(s *Simulation, id NodeId, cfg *NodeConfig) (*Node, error) {
 	}
 
 	go n.lineReader()
+
 	n.AssurePrompt()
 
 	return n, nil
@@ -643,7 +644,7 @@ func (node *Node) expectEOF(timeout time.Duration) {
 				return
 			}
 
-			simplelogger.Warnf("%v - %s", node, readLine)
+			simplelogger.Debugf("%v - %s", node, readLine)
 		}
 	}
 }

--- a/simulation/simulation.go
+++ b/simulation/simulation.go
@@ -60,6 +60,7 @@ func NewSimulation(ctx *progctx.ProgCtx, cfg *Config) (*Simulation, error) {
 	// start the event_dispatcher for virtual time
 	dispatcherCfg := dispatcher.DefaultConfig()
 	dispatcherCfg.Speed = cfg.Speed
+	dispatcherCfg.Real = cfg.Real
 	s.d = dispatcher.NewDispatcher(s.ctx, dispatcherCfg, s)
 	s.vis = s.d.GetVisualizer()
 	if err := s.removeTmpDir(); err != nil {

--- a/simulation/simulation_config.go
+++ b/simulation/simulation_config.go
@@ -42,6 +42,7 @@ type Config struct {
 	Speed       float64
 	ReadOnly    bool
 	RawMode     bool
+	Real        bool
 }
 
 func DefaultConfig() *Config {
@@ -54,5 +55,6 @@ func DefaultConfig() *Config {
 		ReadOnly:    false,
 		RawMode:     false,
 		OtCliPath:   "ot-cli-ftd",
+		Real:        false,
 	}
 }


### PR DESCRIPTION
This PR enhances OTNS to support real devices.
- adds `-real` option which turns on the `Real` mode in which `OTNS` expects the nodes to be real devices. 
- adds `otns-silk-proxy` program to wrap silk devices.

Run OTNS for silk devices:
```
./script/install
otns -raw -real -ot-cli $(which otns-silk-proxy)
```

The major difference between `real` and `simulation` modes are:
- Dispatcher in `real` mode neither receives nor sends `Alarm` and `Radio` events (because they are unnecessary)
- All devices are assumed to be sleeping (not alive), so dispatcher never blocks for receiving UDP events