### PR TITLE
[cmdline] specify OT CLI exe path instead of bin directory

### DIFF
--- a/otns_main/otns_main.go
+++ b/otns_main/otns_main.go
@@ -59,13 +59,13 @@ import (
 )
 
 type MainArgs struct {
-	Speed    string
-	BinDir   string
-	AutoGo   bool
-	ReadOnly bool
-	LogLevel string
-	OpenWeb  bool
-	RawMode  bool
+	Speed     string
+	OtCliPath string
+	AutoGo    bool
+	ReadOnly  bool
+	LogLevel  string
+	OpenWeb   bool
+	RawMode   bool
 }
 
 var (
@@ -74,7 +74,7 @@ var (
 
 func parseArgs() {
 	flag.StringVar(&args.Speed, "speed", "1", "set simulating speed")
-	flag.StringVar(&args.BinDir, "bin", ".", "specify binary directory containing ot-cli-ftd, ot-cli-mtd, etc")
+	flag.StringVar(&args.OtCliPath, "otcli", "ot-cli-ftd", "specify the OT CLI executable")
 	flag.BoolVar(&args.AutoGo, "autogo", true, "auto go")
 	flag.BoolVar(&args.ReadOnly, "readonly", false, "readonly simulation can not be manipulated")
 	flag.StringVar(&args.LogLevel, "log", "warn", "set logging level")
@@ -178,7 +178,7 @@ func createSimulation(ctx *progctx.ProgCtx) *simulation.Simulation {
 	var err error
 
 	simcfg := simulation.DefaultConfig()
-	simcfg.BinDir = args.BinDir
+	simcfg.OtCliPath = args.OtCliPath
 
 	args.Speed = strings.ToLower(args.Speed)
 	if args.Speed == "max" {

--- a/otns_main/otns_main.go
+++ b/otns_main/otns_main.go
@@ -74,7 +74,7 @@ var (
 
 func parseArgs() {
 	flag.StringVar(&args.Speed, "speed", "1", "set simulating speed")
-	flag.StringVar(&args.OtCliPath, "otcli", "ot-cli-ftd", "specify the OT CLI executable")
+	flag.StringVar(&args.OtCliPath, "ot-cli", "ot-cli-ftd", "specify the OT CLI executable")
 	flag.BoolVar(&args.AutoGo, "autogo", true, "auto go")
 	flag.BoolVar(&args.ReadOnly, "readonly", false, "readonly simulation can not be manipulated")
 	flag.StringVar(&args.LogLevel, "log", "warn", "set logging level")

--- a/simulation/node.go
+++ b/simulation/node.go
@@ -59,7 +59,7 @@ func newNode(s *Simulation, id NodeId, cfg *NodeConfig) (*Node, error) {
 		simplelogger.Errorf("Remove flash file %s failed: %+v", flashFile, err)
 	}
 
-	exePath, err := filepath.Abs(filepath.Join(s.BinDir(), "ot-cli-ftd"))
+	exePath, err := filepath.Abs(s.cfg.OtCliPath)
 	if err != nil {
 		return nil, err
 	}

--- a/simulation/simulation.go
+++ b/simulation/simulation.go
@@ -148,10 +148,6 @@ func (s *Simulation) Stop() {
 	s.d.Stop()
 }
 
-func (s *Simulation) BinDir() string {
-	return s.cfg.BinDir
-}
-
 func (s *Simulation) SetVisualizer(vis visualize.Visualizer) {
 	simplelogger.AssertNotNil(vis)
 	s.vis = vis

--- a/simulation/simulation_config.go
+++ b/simulation/simulation_config.go
@@ -38,7 +38,7 @@ type Config struct {
 	MasterKey   string
 	Panid       uint16
 	Channel     int
-	BinDir      string
+	OtCliPath   string
 	Speed       float64
 	ReadOnly    bool
 	RawMode     bool
@@ -53,6 +53,6 @@ func DefaultConfig() *Config {
 		Speed:       1,
 		ReadOnly:    false,
 		RawMode:     false,
-		BinDir:      "",
+		OtCliPath:   "ot-cli-ftd",
 	}
 }


### PR DESCRIPTION
This PR allows specifying OT Cli executable path instead of bin directory.