### PR TITLE
[dispatcher] allow receive UDP events from remote nodes

### DIFF
--- a/dispatcher/Node.go
+++ b/dispatcher/Node.go
@@ -125,6 +125,8 @@ func (node *Node) Send(elapsed uint64, data []byte) {
 func (node *Node) SendMessage(msg []byte) {
 	if node.peerAddr != nil {
 		_, _ = node.D.udpln.WriteToUDP(msg, node.peerAddr)
+	} else {
+		simplelogger.Errorf("%s does not have a peer address", node)
 	}
 }
 

--- a/dispatcher/Node.go
+++ b/dispatcher/Node.go
@@ -74,7 +74,7 @@ type Node struct {
 	CreateTime  uint64
 	CurTime     uint64
 
-	addr          *net.UDPAddr
+	peerAddr      *net.UDPAddr
 	failureCtrl   *FailureCtrl
 	isFailed      bool
 	radioRange    int
@@ -87,8 +87,6 @@ type Node struct {
 
 func newNode(d *Dispatcher, nodeid NodeId, x, y int, radioRange int) *Node {
 	simplelogger.AssertTrue(radioRange >= 0)
-	addr, err := net.ResolveUDPAddr("udp4", fmt.Sprintf("127.0.0.1:%d", 9000+nodeid))
-	simplelogger.AssertNil(err)
 
 	nc := &Node{
 		D:           d,
@@ -99,7 +97,7 @@ func newNode(d *Dispatcher, nodeid NodeId, x, y int, radioRange int) *Node {
 		Y:           y,
 		ExtAddr:     InvalidExtAddr,
 		Rloc16:      threadconst.InvalidRloc16,
-		addr:        addr,
+		peerAddr:    nil, // peer address will be set when the first event is received
 		radioRange:  radioRange,
 		joinerState: OtJoinerStateIdle,
 	}
@@ -125,7 +123,9 @@ func (node *Node) Send(elapsed uint64, data []byte) {
 }
 
 func (node *Node) SendMessage(msg []byte) {
-	_, _ = node.D.udpln.WriteToUDP(msg, node.addr)
+	if node.peerAddr != nil {
+		_, _ = node.D.udpln.WriteToUDP(msg, node.peerAddr)
+	}
 }
 
 func (node *Node) GetDistanceTo(other *Node) (dist int) {

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -131,7 +131,7 @@ type Dispatcher struct {
 func NewDispatcher(ctx *progctx.ProgCtx, cfg *Config, cbHandler CallbackHandler) *Dispatcher {
 	simplelogger.AssertTrue(!cfg.Real || cfg.Speed == 1)
 
-  udpAddr, err := net.ResolveUDPAddr("udp4", ":9000")
+	udpAddr, err := net.ResolveUDPAddr("udp4", ":9000")
 	simplelogger.FatalIfError(err, err)
 	ln, err := net.ListenUDP("udp", udpAddr)
 	simplelogger.FatalIfError(err, err)

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -127,7 +127,7 @@ type Dispatcher struct {
 }
 
 func NewDispatcher(ctx *progctx.ProgCtx, cfg *Config, cbHandler CallbackHandler) *Dispatcher {
-	udpAddr, err := net.ResolveUDPAddr("udp4", "127.0.0.1:9000")
+	udpAddr, err := net.ResolveUDPAddr("udp4", ":9000")
 	simplelogger.FatalIfError(err, err)
 	ln, err := net.ListenUDP("udp", udpAddr)
 	simplelogger.FatalIfError(err, err)
@@ -284,6 +284,10 @@ func (d *Dispatcher) handleRecvEvent(evt *event) {
 			return
 		}
 	}
+
+	// assign source address from event to node
+	node := d.nodes[nodeid]
+	node.peerAddr = evt.SrcAddr
 
 	if d.isWatching(evt.NodeId) {
 		simplelogger.Warnf("Node %d <<< %+v, cur time %d, node time %d, delay %d", evt.NodeId, *evt,
@@ -466,6 +470,7 @@ func (d *Dispatcher) eventsReader() {
 			Type:    typ,
 			DataLen: datalen,
 			Data:    data,
+			SrcAddr: srcaddr,
 		}
 
 		d.eventChan <- evt

--- a/dispatcher/event.go
+++ b/dispatcher/event.go
@@ -26,7 +26,11 @@
 
 package dispatcher
 
-import . "github.com/openthread/ot-ns/types"
+import (
+	"net"
+
+	. "github.com/openthread/ot-ns/types"
+)
 
 const (
 	eventTypeAlarmFired    = 0
@@ -42,4 +46,5 @@ type event struct {
 	NodeId  NodeId
 	DataLen uint16
 	Data    []byte
+	SrcAddr *net.UDPAddr
 }


### PR DESCRIPTION
Originally OTNS listens at 127.0.0.1:9000 for UDP events so it must run locally with simulation nodes. 
This PR enhances OTNS to allow it to receive and send UDP events from remote nodes.

The source address of a received UDP event will be used as the peer address for that node. 
