### PR TITLE
[cli] add runcli package for common CLI logic

### DIFF
--- a/cli/runcli/runcli.go
+++ b/cli/runcli/runcli.go
@@ -1,0 +1,104 @@
+package runcli
+
+import (
+	"io"
+	"os"
+	"strings"
+
+	"github.com/chzyer/readline"
+)
+
+type CliHandler interface {
+	HandleCommand(cmd string, output io.Writer) error
+	GetPrompt() string
+}
+
+type CliOptions struct {
+	EchoInput bool
+}
+
+func RunCli(handler CliHandler, options CliOptions) error {
+	stdinFd := int(os.Stdin.Fd())
+	stdinIsTerminal := readline.IsTerminal(stdinFd)
+	if stdinIsTerminal {
+		stdinState, err := readline.GetState(stdinFd)
+		if err != nil {
+			return err
+		}
+
+		defer func() {
+			_ = readline.Restore(stdinFd, stdinState)
+		}()
+	}
+
+	stdoutFd := int(os.Stdout.Fd())
+	stdoutIsTerminal := readline.IsTerminal(stdoutFd)
+	if stdoutIsTerminal {
+		stdoutState, err := readline.GetState(stdoutFd)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			_ = readline.Restore(stdoutFd, stdoutState)
+		}()
+	}
+
+	l, err := readline.NewEx(&readline.Config{
+		Prompt:          handler.GetPrompt(),
+		InterruptPrompt: "^C",
+		EOFPrompt:       "exit",
+
+		HistorySearchFold: true,
+		FuncFilterInputRune: func(r rune) (rune, bool) {
+			switch r {
+			// block CtrlZ feature
+			case readline.CharCtrlZ:
+				return r, false
+			}
+			return r, true
+		},
+	})
+
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = l.Close()
+	}()
+
+	for {
+		// update the prompt
+		l.SetPrompt(handler.GetPrompt())
+
+		line, err := l.Readline()
+
+		if err == readline.ErrInterrupt {
+			if len(line) == 0 {
+				return nil
+			} else {
+				continue
+			}
+		} else if err == io.EOF {
+			return nil
+		} else if err != nil {
+			return err
+		}
+
+		if options.EchoInput {
+			if _, err := os.Stdout.WriteString(line + "\n"); err != nil {
+				return err
+			}
+		}
+
+		cmd := strings.TrimSpace(line)
+		if len(cmd) == 0 {
+			continue
+		}
+
+		if err = handler.HandleCommand(cmd, l.Stdout()); err != nil {
+			return err
+		}
+
+		_ = os.Stdout.Sync()
+	}
+}

--- a/cmd/real/otns-silk-proxy/otns-silk-proxy.go
+++ b/cmd/real/otns-silk-proxy/otns-silk-proxy.go
@@ -3,100 +3,34 @@ package main
 import (
 	"io"
 	"os"
-	"strings"
 
-	"github.com/chzyer/readline"
+	"github.com/openthread/ot-ns/cli/runcli"
 	"github.com/simonlingoogle/go-simplelogger"
 )
 
-const (
-	Prompt = "> "
-)
+type cliHandler struct{}
 
-func runCli() error {
-	stdinFd := int(os.Stdin.Fd())
-	stdinIsTerminal := readline.IsTerminal(stdinFd)
-	if stdinIsTerminal {
-		stdinState, err := readline.GetState(stdinFd)
-		if err != nil {
-			return err
-		}
+func (c cliHandler) GetPrompt() string {
+	return "> "
+}
 
-		defer func() {
-			_ = readline.Restore(stdinFd, stdinState)
-		}()
-	}
-
-	stdoutFd := int(os.Stdout.Fd())
-	stdoutIsTerminal := readline.IsTerminal(stdoutFd)
-	if stdoutIsTerminal {
-		stdoutState, err := readline.GetState(stdoutFd)
-		if err != nil {
-			return err
-		}
-		defer func() {
-			_ = readline.Restore(stdoutFd, stdoutState)
-		}()
-	}
-
-	l, err := readline.NewEx(&readline.Config{
-		Prompt:          Prompt,
-		InterruptPrompt: "^C",
-		EOFPrompt:       "exit",
-
-		HistorySearchFold: true,
-		FuncFilterInputRune: func(r rune) (rune, bool) {
-			switch r {
-			// block CtrlZ feature
-			case readline.CharCtrlZ:
-				return r, false
-			}
-			return r, true
-		},
-	})
-
-	if err != nil {
+func (c cliHandler) HandleCommand(cmd string, output io.Writer) error {
+	if _, err := output.Write([]byte("Done\n")); err != nil {
 		return err
 	}
-	defer func() {
-		_ = l.Close()
-	}()
 
-	for {
-		line, err := l.Readline()
-
-		if err == readline.ErrInterrupt {
-			if len(line) == 0 {
-				return nil
-			} else {
-				continue
-			}
-		} else if err == io.EOF {
-			return nil
-		} else if err != nil {
-			return err
-		}
-
-		_, _ = os.Stdout.WriteString(line + "\n")
-
-		cmd := strings.TrimSpace(line)
-		if len(cmd) == 0 {
-			continue
-		}
-
-		// just output Done for all commands because the silk proxy does not manage the devices
-		_, _ = os.Stdout.WriteString("Done\n")
-
-		if cmd == "exit" {
-			os.Exit(0)
-		}
-
-		_ = os.Stdout.Sync()
+	if cmd == "exit" {
+		os.Exit(0)
 	}
+
+	return nil
 }
 
 func main() {
-	err := runCli()
+	err := runcli.RunCli(&cliHandler{}, runcli.CliOptions{
+		EchoInput: true,
+	})
+
 	if err != nil {
 		simplelogger.Error(err)
 	}


### PR DESCRIPTION
`OTNS Cli` and `otns-silk-proxy` use almost same CLI logic that uses `readline`.
This PR adds a new `runcli` package that encapsulate these logic to reduce duplicated code. 