### PR TITLE
[simulation] auto detects whether a node uses virtual time UART

### DIFF
--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -64,16 +64,14 @@ type pcapFrameItem struct {
 }
 
 type Config struct {
-	Speed           float64
-	Real            bool
-	VirtualTimeUART bool
+	Speed float64
+	Real  bool
 }
 
 func DefaultConfig() *Config {
 	return &Config{
-		Speed:           1,
-		Real:            false,
-		VirtualTimeUART: false,
+		Speed: 1,
+		Real:  false,
 	}
 }
 
@@ -542,8 +540,6 @@ func (d *Dispatcher) advanceNodeTime(id NodeId, timestamp uint64, force bool) {
 
 // SendToUART sends data to virtual time UART of the target node.
 func (d *Dispatcher) SendToUART(id NodeId, data []byte) {
-	simplelogger.AssertTrue(d.cfg.VirtualTimeUART)
-
 	node := d.nodes[id]
 
 	oldTime := node.CurTime
@@ -1205,9 +1201,6 @@ func (d *Dispatcher) SetVisualizationOptions(opts VisualizationOptions) {
 }
 
 func (d *Dispatcher) handleUartWrite(nodeid NodeId, data []byte) {
-	if !d.cfg.VirtualTimeUART {
-		simplelogger.Fatalf("should use Virtual Time UART: -virtual-time-uart=true")
-	}
 	d.cbHandler.OnUartWrite(nodeid, data)
 }
 

--- a/otns_main/otns_main.go
+++ b/otns_main/otns_main.go
@@ -194,20 +194,7 @@ func createSimulation(ctx *progctx.ProgCtx) *simulation.Simulation {
 	simcfg.RawMode = args.RawMode
 	simcfg.Real = args.Real
 
-	simcfg.VirtualTimeUART = parseVirtualTimeUARTFromEnv()
-
 	sim, err := simulation.NewSimulation(ctx, simcfg)
 	simplelogger.FatalIfError(err)
 	return sim
-}
-
-func parseVirtualTimeUARTFromEnv() bool {
-	val := os.Getenv("VIRTUAL_TIME_UART")
-	if val == "" {
-		val = "0"
-	}
-	simplelogger.Infof("env VIRTUAL_TIME_UART=%s", val)
-	ival, err := strconv.Atoi(val)
-	simplelogger.FatalfIfError(err, "invalid VIRTUAL_TIME_UART: %s", val)
-	return ival != 0
 }

--- a/simulation/simulation.go
+++ b/simulation/simulation.go
@@ -61,7 +61,6 @@ func NewSimulation(ctx *progctx.ProgCtx, cfg *Config) (*Simulation, error) {
 	dispatcherCfg := dispatcher.DefaultConfig()
 	dispatcherCfg.Speed = cfg.Speed
 	dispatcherCfg.Real = cfg.Real
-	dispatcherCfg.VirtualTimeUART = cfg.VirtualTimeUART
 	s.d = dispatcher.NewDispatcher(s.ctx, dispatcherCfg, s)
 	s.vis = s.d.GetVisualizer()
 	if err := s.removeTmpDir(); err != nil {
@@ -100,7 +99,8 @@ func (s *Simulation) AddNode(cfg *NodeConfig) (*Node, error) {
 		FullNetworkData:    true,
 	})
 
-	node.AssurePrompt()
+	node.detectVirtualTimeUART()
+
 	node.setupMode()
 
 	if !s.rawMode {
@@ -180,8 +180,6 @@ func (s *Simulation) OnNodeRecover(nodeid NodeId) {
 // OnUartWrite notifies the simulation that a node has received some data from UART.
 // It is part of implementation of dispatcher.CallbackHandler.
 func (s *Simulation) OnUartWrite(nodeid NodeId, data []byte) {
-	simplelogger.AssertTrue(s.cfg.VirtualTimeUART)
-
 	node := s.nodes[nodeid]
 	if node == nil {
 		return

--- a/simulation/simulation_config.go
+++ b/simulation/simulation_config.go
@@ -47,14 +47,14 @@ type Config struct {
 
 func DefaultConfig() *Config {
 	return &Config{
-		NetworkName:     DefaultNetworkName,
-		MasterKey:       DefaultMasterKey,
-		Panid:           DefaultPanid,
-		Channel:         DefaultChannel,
-		Speed:           1,
-		ReadOnly:        false,
-		RawMode:         false,
-		OtCliPath:       "./ot-cli-ftd",
-		Real:            false,
+		NetworkName: DefaultNetworkName,
+		MasterKey:   DefaultMasterKey,
+		Panid:       DefaultPanid,
+		Channel:     DefaultChannel,
+		Speed:       1,
+		ReadOnly:    false,
+		RawMode:     false,
+		OtCliPath:   "./ot-cli-ftd",
+		Real:        false,
 	}
 }

--- a/simulation/simulation_config.go
+++ b/simulation/simulation_config.go
@@ -34,16 +34,15 @@ const (
 )
 
 type Config struct {
-	NetworkName     string
-	MasterKey       string
-	Panid           uint16
-	Channel         int
-	OtCliPath       string
-	Speed           float64
-	ReadOnly        bool
-	RawMode         bool
-	Real            bool
-	VirtualTimeUART bool
+	NetworkName string
+	MasterKey   string
+	Panid       uint16
+	Channel     int
+	OtCliPath   string
+	Speed       float64
+	ReadOnly    bool
+	RawMode     bool
+	Real        bool
 }
 
 func DefaultConfig() *Config {
@@ -57,6 +56,5 @@ func DefaultConfig() *Config {
 		RawMode:         false,
 		OtCliPath:       "./ot-cli-ftd",
 		Real:            false,
-		VirtualTimeUART: false,
 	}
 }


### PR DESCRIPTION
This PR enhances OTNS to auto-detect if a node uses virtual time UART, instead of depending on OS env `VIRTUAL_TIME_UART`. 

This PR should allow OTNS to work transparently with OpenThread simulation of both UART types, and even to create nodes of both types at the same time (but it's not tested).