### PR TITLE
[real] fix delete node error

### DIFF
--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -1213,5 +1213,7 @@ func (d *Dispatcher) handleUartWrite(nodeid NodeId, data []byte) {
 
 // NotifyExit notifies the dispatcher that the node process has exited.
 func (d *Dispatcher) NotifyExit(nodeid NodeId) {
-	d.setSleeping(nodeid)
+	if !d.cfg.Real {
+		d.setSleeping(nodeid)
+	}
 }


### PR DESCRIPTION
This PR fixes a bug that deleting a node in real mode fails. 

**Should never call `setSleeping` for real devices because they are always sleeping**