### PR TITLE
[cli] allow specify OT executable when adding nodes

### DIFF
--- a/cli/CmdRunner.go
+++ b/cli/CmdRunner.go
@@ -286,6 +286,10 @@ func (rt *CmdRunner) executeAddNode(cc *CommandContext, cmd *AddCmd) {
 		cfg.RadioRange = cmd.RadioRange.Val
 	}
 
+	if cmd.Executable != nil {
+		cfg.ExecutablePath = cmd.Executable.Path
+	}
+
 	rt.postAsyncWait(func(sim *simulation.Simulation) {
 		node, err := sim.AddNode(cfg)
 		if err != nil {

--- a/cli/ast.go
+++ b/cli/ast.go
@@ -235,12 +235,19 @@ type AddCmd struct {
 	X          *int            `( "x" (@Int|@Float) ` //nolint
 	Y          *int            `| "y" (@Int|@Float) ` //nolint
 	Id         *AddNodeId      `| @@`                 //nolint
-	RadioRange *RadioRangeFlag `|@@ )*`               //nolint
+	RadioRange *RadioRangeFlag `| @@`                 //nolint
+	Executable *ExecutableFlag `| @@ )*`              //nolint
 }
 
 //noinspection GoStructTag
 type RadioRangeFlag struct {
 	Val int `"rr" @Int` //nolint
+}
+
+//noinspection GoStructTag
+type ExecutableFlag struct {
+	Dummy struct{} `"exe"`   //nolint
+	Path  string   `@String` //nolint
 }
 
 //noinspection MaxSpeedFlag

--- a/pylibs/otns/cli/OTNS.py
+++ b/pylibs/otns/cli/OTNS.py
@@ -155,7 +155,7 @@ class OTNS(object):
 
             output.append(line)
 
-    def add(self, type: str, x: float = None, y: float = None, id=None, radio_range=None) -> int:
+    def add(self, type: str, x: float = None, y: float = None, id=None, radio_range=None, executable=None) -> int:
         """
         Add a new node to the simulation.
 
@@ -164,6 +164,7 @@ class OTNS(object):
         :param y: node position Y
         :param id: node ID, or None to use next available node ID
         :param radio_range: node radio range or None for default
+        :param executable: specify the executable for the new node, or use default executable if None
 
         :return: added node ID
         """
@@ -178,6 +179,9 @@ class OTNS(object):
 
         if radio_range is not None:
             cmd += f' rr {radio_range}'
+
+        if executable:
+            cmd += f' exe "{executable}"'
 
         return self._expect_int(self._do_command(cmd))
 

--- a/simulation/node.go
+++ b/simulation/node.go
@@ -60,8 +60,12 @@ func newNode(s *Simulation, id NodeId, cfg *NodeConfig) (*Node, error) {
 		simplelogger.Errorf("Remove flash file %s failed: %+v", flashFile, err)
 	}
 
-	simplelogger.Debugf("node exe path: %s", s.cfg.OtCliPath)
-	cmd := exec.CommandContext(context.Background(), s.cfg.OtCliPath, strconv.Itoa(id))
+	otCliPath := s.cfg.OtCliPath
+	if cfg.ExecutablePath != "" {
+		otCliPath = cfg.ExecutablePath
+	}
+	simplelogger.Debugf("node exe path: %s", otCliPath)
+	cmd := exec.CommandContext(context.Background(), otCliPath, strconv.Itoa(id))
 
 	node := &Node{
 		S:            s,

--- a/simulation/node_config.go
+++ b/simulation/node_config.go
@@ -27,22 +27,24 @@
 package simulation
 
 type NodeConfig struct {
-	ID            int
-	X, Y          int
-	IsMtd         bool
-	IsRouter      bool
-	RxOffWhenIdle bool
-	RadioRange    int
+	ID             int
+	X, Y           int
+	IsMtd          bool
+	IsRouter       bool
+	RxOffWhenIdle  bool
+	RadioRange     int
+	ExecutablePath string
 }
 
 func DefaultNodeConfig() *NodeConfig {
 	return &NodeConfig{
-		ID:            -1, // -1 for the next available nodeid
-		X:             0,
-		Y:             0,
-		IsRouter:      true,
-		IsMtd:         false,
-		RxOffWhenIdle: false,
-		RadioRange:    160,
+		ID:             -1, // -1 for the next available nodeid
+		X:              0,
+		Y:              0,
+		IsRouter:       true,
+		IsMtd:          false,
+		RxOffWhenIdle:  false,
+		RadioRange:     160,
+		ExecutablePath: "",
 	}
 }


### PR DESCRIPTION
This PR allows users to specify a different OT executable when adding nodes instead of the default executable configured by `-ot-cli <executable>`.