### PR TITLE
[scripts] repeat bootstrap openthread for 3 times

### DIFF
--- a/script/test
+++ b/script/test
@@ -28,7 +28,7 @@
 # shellcheck source=script/common.sh
 . "$(dirname "$0")"/common.sh
 
-set -e
+set -euox pipefail
 
 OT_DIR=${OT_DIR:-$HOME/src/openthread}
 if [[ $(uname) == "Darwin" ]]; then
@@ -74,10 +74,10 @@ get_openthread()
 {
     if ! [[ -x $OT_DIR ]]; then
         mkdir -p "$(dirname "$OT_DIR")"
-        git clone https://github.com/openthread/openthread.git "$OT_DIR"
+        git clone https://github.com/openthread/openthread.git "$OT_DIR" --branch master --depth 1
         (
             cd "$OT_DIR"
-            ./script/bootstrap
+            repeat 3 ./script/bootstrap
             ./bootstrap
         )
     fi


### PR DESCRIPTION
Running `./script/bootstrap` for `openthread` often fail when installing `shellcheck`. For example: [log](https://pipelines.actions.githubusercontent.com/yK5b9HpAJKCrbAcBv28ULmQ0nqYkgcTG4HVYvTZeTCAh35Bb7R/_apis/pipelines/1/runs/947/signedlogcontent/18?urlExpires=2020-07-11T16%3A25%3A27.7314832Z&urlSigningMethod=HMACV1&urlSignature=eB%2BJ6ZrTsbGDTZGLiW0FJLvW0hb%2Fxjvha869PVXfnWc%3D).

This PR repeats bootstrapping openthread for multiple times to reduce false fails.

