### PR TITLE
[stress-tests] add the large_network_forming stress test

### DIFF
--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -57,5 +57,7 @@ jobs:
           mkdir -p /home/runner/work/_temp/_github_home
       - uses: actions/checkout@v2
       - name: Stress Test
+        env:
+          STRESS_LEVEL: 10
         run: |
           ./script/test stress-tests ${{ matrix.suite }}

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -1,0 +1,69 @@
+# Copyright (c) 2020, The OTNS Authors.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the
+#    names of its contributors may be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+name: Stress
+
+on: [push, pull_request]
+
+jobs:
+  cancel-previous-runs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: rokroskar/workflow-run-cleanup-action@master
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        if: "github.ref != 'refs/heads/master'"
+
+  stress-tests:
+    name: "Test Suite ${{ matrix.suite }}"
+    strategy:
+      matrix:
+        python-version: [3.8]
+        go-version: [1.14]
+        suite: ["network-forming"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: |
+          mkdir -p /home/runner/work/_temp/_github_home
+      - uses: actions/checkout@v2
+      - name: Stress Test
+        run: |
+          ./script/test stress-tests ${{ matrix.suite }}
+  stress-report:
+    name: Generate Report
+    runs-on: ubuntu-latest
+    needs: [stress-tests]
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          ./script/test gen-stress-tests-report

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -59,11 +59,3 @@ jobs:
       - name: Stress Test
         run: |
           ./script/test stress-tests ${{ matrix.suite }}
-  stress-report:
-    name: Generate Report
-    runs-on: ubuntu-latest
-    needs: [stress-tests]
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          ./script/test gen-stress-tests-report

--- a/pylibs/stress_tests/BaseStressTest.py
+++ b/pylibs/stress_tests/BaseStressTest.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+#
 # Copyright (c) 2020, The OTNS Authors.
 # All rights reserved.
 #
@@ -24,6 +25,7 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+#
 import os
 import sys
 import time

--- a/pylibs/stress_tests/BaseStressTest.py
+++ b/pylibs/stress_tests/BaseStressTest.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020, The OTNS Authors.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the
+#    names of its contributors may be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+import os
+import sys
+import time
+import traceback
+from functools import wraps
+
+from StressTestResult import StressTestResult
+from otns.cli import OTNS
+
+
+class StressTestMetaclass(type):
+    def __new__(cls, name, bases, dct):
+        assert 'run' in dct, f'run method is not defined in {name}'
+
+        orig_run = dct.pop('run')
+
+        @wraps(orig_run)
+        def run_wrapper(self: 'BaseStressTest', report=True):
+            try:
+                orig_run(self)
+            except Exception as ex:
+                traceback.print_exc()
+                self.result.fail_with_error(ex)
+            finally:
+                self.stop()
+
+            if report:
+                self.report()
+
+        dct['run'] = run_wrapper
+
+        t = super().__new__(cls, name, bases, dct)
+        return t
+
+
+class BaseStressTest(object, metaclass=StressTestMetaclass):
+    def __init__(self, name, headers, raw=False):
+        self.name = name
+        self._otns_args = []
+        if raw:
+            self._otns_args.append('-raw')
+        self.ns = OTNS(otns_args=self._otns_args)
+        self.ns.speed = float('inf')
+        self.ns.web()
+
+        self.result = StressTestResult(name=name, headers=headers)
+        self.result.start()
+
+    def run(self):
+        raise NotImplementedError()
+
+    def reset(self):
+        nodes = self.ns.nodes()
+        if nodes:
+            self.ns.delete(*nodes.keys())
+
+    def stop(self):
+        self.result.stop()
+        self.ns.close()
+
+    def report(self):
+        try:
+            STRESS_RESULT_FILE = os.environ['STRESS_RESULT_FILE']
+            stress_result_fd = open(STRESS_RESULT_FILE, 'wt')
+        except KeyError:
+            stress_result_fd = sys.stdout
+
+        with stress_result_fd:
+            stress_result_fd.write(
+                f"""**[OTNS](https://github.com/openthread/ot-ns) Stress Tests Report Generated at {time.strftime(
+                    "%m/%d %H:%M:%S")}**\n""")
+            stress_result_fd.write(self.result.format())

--- a/pylibs/stress_tests/StressTestResult.py
+++ b/pylibs/stress_tests/StressTestResult.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+#
 # Copyright (c) 2020, The OTNS Authors.
 # All rights reserved.
 #
@@ -24,6 +25,7 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+#
 
 import time
 

--- a/pylibs/stress_tests/StressTestResult.py
+++ b/pylibs/stress_tests/StressTestResult.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020, The OTNS Authors.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the
+#    names of its contributors may be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import time
+
+from typing import Sequence, Any
+
+
+class StressTestResult(object):
+
+    def __init__(self, name: str, headers: Sequence[str]):
+        self.name = name
+        self.headers = tuple(headers)
+        self.rows = []
+        self._start_time = None
+        self._stop_time = None
+        self._failed = False
+        self._fail_msgs = []
+        self._fail_exception = None
+
+    @property
+    def failed(self):
+        return self._failed
+
+    def start(self):
+        assert self._start_time is None
+        self._start_time = time.time()
+
+    def stop(self):
+        assert self._start_time is not None and self._stop_time is None
+        self._stop_time = time.time()
+
+    def fail_with_error(self, ex: Exception):
+        assert self._fail_exception is None
+        self._fail_exception = ex
+        self._failed = True
+        self._fail_msgs.append(str(ex))
+
+    def fail_if(self, cond: bool, msg: str = ""):
+        if cond:
+            self._failed = True
+            self._fail_msgs.append(msg)
+
+    @property
+    def column_num(self):
+        return len(self.headers)
+
+    def append_row(self, *values: Any):
+        assert len(values) == len(self.headers)
+        self.rows.append(values)
+
+    def format(self):
+        rows = [self.headers, [':-:'] * self.column_num]
+        rows.extend(self.rows)
+        rows = ['| ' + ' | '.join(map(str, row)) + ' |' for row in rows]
+        start_time = time.strftime("%m/%d %H:%M:%S", time.gmtime(self._start_time))
+        stop_time = time.strftime("%m/%d %H:%M:%S", time.gmtime(self._stop_time))
+        passed_str = 'Passed' if not self._failed else 'Failed'
+        fail_msg = ', '.join(self._fail_msgs)
+        if fail_msg:
+            fail_msg = ': ' + fail_msg
+
+        return f'#### {self.name} **{passed_str}**{fail_msg} _({start_time} ~ {stop_time})_\n' + '\n'.join(
+            rows) + '\n'

--- a/pylibs/stress_tests/large_network_forming.py
+++ b/pylibs/stress_tests/large_network_forming.py
@@ -34,9 +34,10 @@ YGAP = 100
 RADIO_RANGE = int(XGAP * 1.5)
 
 LARGE_N = 8
+PACKET_LOSS_RATIO = 0.9
 
-SIMULATE_TIME = 60
-REPEAT = 100 if os.getenv('GITHUB_ACTIONS') else 1
+SIMULATE_TIME = 3600
+REPEAT = 10 if os.getenv('GITHUB_ACTIONS') else 1
 
 
 class StressTest(BaseStressTest):
@@ -47,7 +48,7 @@ class StressTest(BaseStressTest):
                                          ["Simulation Time", "Execution Time", "Average Partition Count in 60s"])
 
     def run(self):
-        self.ns.packet_loss_ratio = 0.2
+        self.ns.packet_loss_ratio = PACKET_LOSS_RATIO
 
         durations = []
         partition_counts = []
@@ -64,7 +65,8 @@ class StressTest(BaseStressTest):
 
         for r in range(n):
             for c in range(n):
-                self.ns.add("router", 50 + XGAP * c, 50 + YGAP * r, radio_range=RADIO_RANGE)
+                id = self.ns.add("router", 50 + XGAP * c, 50 + YGAP * r, radio_range=RADIO_RANGE)
+                self.ns.node_cmd(id, f'childtimeout {5}')
 
         t0 = time.time()
         self.ns.go(SIMULATE_TIME)

--- a/pylibs/stress_tests/large_network_forming.py
+++ b/pylibs/stress_tests/large_network_forming.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020, The OTNS Authors.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the
+#    names of its contributors may be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+import os
+import time
+
+from BaseStressTest import BaseStressTest
+
+XGAP = 100
+YGAP = 100
+RADIO_RANGE = int(XGAP * 1.5)
+
+LARGE_N = 8
+
+SIMULATE_TIME = 60
+REPEAT = 100 if os.getenv('GITHUB_ACTIONS') else 1
+
+
+class StressTest(BaseStressTest):
+    SUITE = 'network-forming'
+
+    def __init__(self):
+        super(StressTest, self).__init__("Large Network Formation Test",
+                                         ["Simulation Time", "Execution Time", "Average Partition Count in 60s"])
+
+    def run(self):
+        self.ns.packet_loss_ratio = 0.2
+
+        durations = []
+        partition_counts = []
+        for _ in range(REPEAT):
+            dt, par_cnt = self.test_n(LARGE_N)
+            durations.append(dt)
+            partition_counts.append(par_cnt)
+
+        self.result.append_row('%ds' % (SIMULATE_TIME * REPEAT), '%ds' % sum(durations),
+                               '%d' % (sum(partition_counts) / len(partition_counts)))
+
+    def test_n(self, n):
+        self.reset()
+
+        for r in range(n):
+            for c in range(n):
+                self.ns.add("router", 50 + XGAP * c, 50 + YGAP * r, radio_range=RADIO_RANGE)
+
+        t0 = time.time()
+        self.ns.go(SIMULATE_TIME)
+        dt = time.time() - t0
+        return dt, len(self.ns.partitions())
+
+
+if __name__ == '__main__':
+    StressTest().run()

--- a/pylibs/stress_tests/large_network_forming.py
+++ b/pylibs/stress_tests/large_network_forming.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+#
 # Copyright (c) 2020, The OTNS Authors.
 # All rights reserved.
 #
@@ -24,6 +25,7 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+#
 import os
 import time
 
@@ -37,7 +39,7 @@ LARGE_N = 8
 PACKET_LOSS_RATIO = 0.9
 
 SIMULATE_TIME = 3600
-REPEAT = 10 if os.getenv('GITHUB_ACTIONS') else 1
+REPEAT = int(os.getenv('STRESS_LEVEL', '1'))
 
 
 class StressTest(BaseStressTest):

--- a/pylibs/stress_tests/run_stress_suite.py
+++ b/pylibs/stress_tests/run_stress_suite.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020, The OTNS Authors.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the
+#    names of its contributors may be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import inspect
+import logging
+import sys
+import os
+
+
+def find_stress_test_classes(mod, suite_name: str):
+    from BaseStressTest import BaseStressTest
+
+    sts = []
+    for name, member in inspect.getmembers(mod):
+        if not isinstance(member, type):
+            continue
+
+        if issubclass(member, BaseStressTest) and member is not BaseStressTest:
+            assert hasattr(member, 'SUITE') and isinstance(member.SUITE,
+                                                           str), f'Please define `SUITE` for {member.__name__}'
+            if member.SUITE == suite_name:
+                sts.append(member)
+
+    return sts
+
+
+def main():
+    logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s', level=logging.DEBUG)
+
+    script_path = sys.argv[0]
+    script_dir = os.path.abspath(os.path.dirname(script_path))
+    logging.info('script directory: %s' % script_dir)
+
+    suite_names = sys.argv[1:]
+    if not suite_names:
+        logging.error("suite names not specified, nothing to do")
+        exit(-1)
+
+    logging.info("Running stress test suite: %s ...", ', '.join(suite_names))
+
+    sys.path.insert(0, script_dir)
+
+    for suite_name in suite_names:
+        run_suite(script_dir, suite_name)
+
+
+def run_suite(script_dir, suite_name: str):
+    stress_tests = []
+    for filename in os.listdir(script_dir):
+        if not filename.endswith('.py'):
+            continue
+
+        modname = os.path.splitext(filename)[0]
+        mod = __import__(modname)
+        stress_test_classes = find_stress_test_classes(mod, suite_name)
+        if not stress_test_classes:
+            continue
+
+        stress_tests.append((filename, stress_test_classes))
+
+    for filename, clses in sorted(stress_tests):
+        for cls in clses:
+            t = cls()
+            logging.info("Running stress test: %s ...", t.name)
+            t.run(report=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/pylibs/stress_tests/run_stress_suite.py
+++ b/pylibs/stress_tests/run_stress_suite.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+#
 # Copyright (c) 2020, The OTNS Authors.
 # All rights reserved.
 #
@@ -24,6 +25,7 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+#
 
 import inspect
 import logging

--- a/script/test
+++ b/script/test
@@ -141,8 +141,8 @@ stress_tests()
     install_deps
     install_otns
     build_openthread
-    cd $OTBIN_DIR
-    python3 $OTNSDIR/pylibs/stress_tests/run_stress_suite.py "$@"
+    cd "$OTBIN_DIR"
+    python3 "$OTNSDIR"/pylibs/stress_tests/run_stress_suite.py "$@"
     cd -
 }
 
@@ -167,7 +167,7 @@ main()
                 shift 1
                 ;;
             stress-tests)
-                stress_tests $2
+                stress_tests "$2"
                 shift 2
                 ;;
             *)

--- a/script/test
+++ b/script/test
@@ -136,40 +136,46 @@ test_signals()
     cd -
 }
 
+stress_tests()
+{
+    install_deps
+    install_otns
+    build_openthread
+    cd $OTBIN_DIR
+    python3 $OTNSDIR/pylibs/stress_tests/run_stress_suite.py "$@"
+    cd -
+}
+
 main()
 {
-    do_go_tests=0
-    do_py_unittests=0
-    do_py_examples=0
-    do_signals=0
-
-    for var in "$@"; do
-        if [[ $var == "go-tests" ]]; then
-            do_go_tests=1
-        elif [[ $var == "py-unittests" ]]; then
-            do_py_unittests=1
-        elif [[ $var == "py-examples" ]]; then
-            do_py_examples=1
-        elif [[ $var == "signals" ]]; then
-            do_signals=1
-        fi
+    while (("$#")); do
+        case "$1" in
+            go-tests)
+                go_tests
+                shift 1
+                ;;
+            py-unittests)
+                py_unittests
+                shift 1
+                ;;
+            py-examples)
+                py_examples
+                shift 1
+                ;;
+            signals)
+                test_signals
+                shift 1
+                ;;
+            stress-tests)
+                stress_tests $2
+                shift 2
+                ;;
+            *)
+                echo "Error: Unsupported test $1" >&2
+                return 1
+                ;;
+        esac
     done
-
-    if [[ $do_go_tests == "1" ]]; then
-        go_tests
-    fi
-
-    if [[ $do_py_unittests == "1" ]]; then
-        py_unittests
-    fi
-
-    if [[ $do_py_examples == "1" ]]; then
-        py_examples
-    fi
-
-    if [[ $do_signals == "1" ]]; then
-        test_signals
-    fi
 }
 
 main "$@"


### PR DESCRIPTION
This PR adds the `large_network_forming` stress test. 

The stress test creates 8x8 nodes and wait for them to form partitions. 
- Random packet loss is used to make the network not that stable so that corner cases can be checked. 
- The test executes for  10 hours in simulating time (much less in actual time).
- The test passes as long as no node crashes. 

This is one of the tests of #11, but I plan to divide it into multiple PRs to ease code reviewing.  

**This very stress test revealed subtle bugs fixed by https://github.com/openthread/openthread/pull/4860.**
