### PR TITLE
[real] do not wait for extaddr change from real devices

### DIFF
--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -863,19 +863,21 @@ func (d *Dispatcher) AddNode(nodeid NodeId, x, y int, radioRange int, mode NodeM
 	simplelogger.Infof("dispatcher add node %d", nodeid)
 	node := d.newNode(nodeid, x, y, radioRange, mode)
 
-	// Wait until node's extended address is emitted
-	// This helps OTNS to make sure that the child process is ready to receive UDP events
-	t0 := time.Now()
-	deadline := t0.Add(time.Second * 10)
-	for node.ExtAddr == InvalidExtAddr && time.Now().Before(deadline) {
-		d.RecvEvents()
-	}
+	if !d.cfg.Real {
+		// Wait until node's extended address is emitted (but not for real devices)
+		// This helps OTNS to make sure that the child process is ready to receive UDP events
+		t0 := time.Now()
+		deadline := t0.Add(time.Second * 10)
+		for node.ExtAddr == InvalidExtAddr && time.Now().Before(deadline) {
+			d.RecvEvents()
+		}
 
-	if node.ExtAddr == InvalidExtAddr {
-		simplelogger.Panicf("expect node %d's extaddr to be valid, but failed", nodeid)
-	} else {
-		takeTime := time.Since(t0)
-		simplelogger.Debugf("node %d's extaddr becomes valid in %v", nodeid, takeTime)
+		if node.ExtAddr == InvalidExtAddr {
+			simplelogger.Panicf("expect node %d's extaddr to be valid, but failed", nodeid)
+		} else {
+			takeTime := time.Since(t0)
+			simplelogger.Debugf("node %d's extaddr becomes valid in %v", nodeid, takeTime)
+		}
 	}
 }
 

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -285,11 +285,10 @@ func (d *Dispatcher) handleRecvEvent(evt *event) {
 	if _, ok := d.nodes[nodeid]; !ok {
 		if _, deleted := d.deletedNodes[nodeid]; !deleted {
 			// can not find the node, and the node is not registered (created by OTNS)
-			d.newNode(nodeid, -1, -1, 10000, DefaultNodeMode())
-		} else {
-			// the node is already deleted, ignore this message
-			return
+			simplelogger.Warnf("unexpect event (type %v) received from Node %v", evt.Type, evt.NodeId)
 		}
+
+		return
 	}
 
 	// assign source address from event to node


### PR DESCRIPTION
Some background on why OTNS expects the node to send `extaddr` status right after node being created:
This feature was added when `Virtual Time UART` was supported by #5 

OT Simulation that uses Virtual time UART receives/sends CLI input/output via UDP events, instead of stdin/stdout.
After the node is created, OTNS needs to send CLI commands to it immediately, e.g. `mode rsdn`, `thread start`, etc. But it is likely that the simulation instance has not opened the UDP port for receiving UDP messages and thus the CLI commands could be lost. So, OTNS needs a way to know that the node is ready for receiving UDP messages before sending any CLI commands. A simple and straightforward way of doing this is by receiving any UDP message from the node. 
Since `extaddr` status is the first UDP message and is always sent (to my observation), OTNS waits for the `extaddr` event to come. 

This however isn't true for Silk devices.