### PR TITLE
[dispatcher] increase timeout for the first extaddr event

### DIFF
--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -866,7 +866,7 @@ func (d *Dispatcher) AddNode(nodeid NodeId, x, y int, radioRange int, mode NodeM
 		// Wait until node's extended address is emitted (but not for real devices)
 		// This helps OTNS to make sure that the child process is ready to receive UDP events
 		t0 := time.Now()
-		deadline := t0.Add(time.Second * 10)
+		deadline := t0.Add(time.Second * 30)
 		for node.ExtAddr == InvalidExtAddr && time.Now().Before(deadline) {
 			d.RecvEvents()
 		}

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -866,9 +866,22 @@ func (d *Dispatcher) AddNode(nodeid NodeId, x, y int, radioRange int, mode NodeM
 		// Wait until node's extended address is emitted (but not for real devices)
 		// This helps OTNS to make sure that the child process is ready to receive UDP events
 		t0 := time.Now()
-		deadline := t0.Add(time.Second * 30)
+		deadline := t0.Add(time.Second * 10)
 		for node.ExtAddr == InvalidExtAddr && time.Now().Before(deadline) {
 			d.RecvEvents()
+		}
+
+		if node.ExtAddr == InvalidExtAddr {
+			deadline := time.Now().Add(time.Second * 60)
+			for node.ExtAddr == InvalidExtAddr && time.Now().Before(deadline) {
+				d.RecvEvents()
+			}
+
+			if node.ExtAddr == InvalidExtAddr {
+				simplelogger.Panicf("expect node %d's extaddr to be valid, but failed in 70s", nodeid)
+			} else {
+				simplelogger.Panicf("expect node %d's extaddr to be valid, but failed in 10s, succeed at %v", nodeid, time.Now().Sub(t0))
+			}
 		}
 
 		if node.ExtAddr == InvalidExtAddr {


### PR DESCRIPTION
Increased from 10s to 30s to see if `form_partition.py` still fails in CI. 

I tend to believe that the VMs of Github CI might just schedule the CPU away for like 10s without running any job. So we should use longer timeout for GitHub Actions. 

```python
>>> "Successful test executions: ||||||||||||X|||||||".count("|")
19
```