### PR TITLE
[dispatcher] allow specify listen address

### DIFF
--- a/cli/CmdRunner.go
+++ b/cli/CmdRunner.go
@@ -701,7 +701,6 @@ func (rt *CmdRunner) enterNodeContext(nodeid NodeId) bool {
 }
 
 func (rt *CmdRunner) executeTitle(cc *CommandContext, cmd *TitleCmd) {
-	simplelogger.Warnf("title %#v", cmd)
 	rt.postAsyncWait(func(sim *simulation.Simulation) {
 		titleInfo := visualize.DefaultTitleInfo()
 

--- a/simulation/simulation.go
+++ b/simulation/simulation.go
@@ -61,6 +61,9 @@ func NewSimulation(ctx *progctx.ProgCtx, cfg *Config) (*Simulation, error) {
 	dispatcherCfg := dispatcher.DefaultConfig()
 	dispatcherCfg.Speed = cfg.Speed
 	dispatcherCfg.Real = cfg.Real
+	dispatcherCfg.Host = cfg.DispatcherHost
+	dispatcherCfg.Port = cfg.DispatcherPort
+
 	s.d = dispatcher.NewDispatcher(s.ctx, dispatcherCfg, s)
 	s.vis = s.d.GetVisualizer()
 	if err := s.removeTmpDir(); err != nil {

--- a/simulation/simulation_config.go
+++ b/simulation/simulation_config.go
@@ -34,27 +34,31 @@ const (
 )
 
 type Config struct {
-	NetworkName string
-	MasterKey   string
-	Panid       uint16
-	Channel     int
-	OtCliPath   string
-	Speed       float64
-	ReadOnly    bool
-	RawMode     bool
-	Real        bool
+	NetworkName    string
+	MasterKey      string
+	Panid          uint16
+	Channel        int
+	OtCliPath      string
+	Speed          float64
+	ReadOnly       bool
+	RawMode        bool
+	Real           bool
+	DispatcherHost string
+	DispatcherPort int
 }
 
 func DefaultConfig() *Config {
 	return &Config{
-		NetworkName: DefaultNetworkName,
-		MasterKey:   DefaultMasterKey,
-		Panid:       DefaultPanid,
-		Channel:     DefaultChannel,
-		Speed:       1,
-		ReadOnly:    false,
-		RawMode:     false,
-		OtCliPath:   "./ot-cli-ftd",
-		Real:        false,
+		NetworkName:    DefaultNetworkName,
+		MasterKey:      DefaultMasterKey,
+		Panid:          DefaultPanid,
+		Channel:        DefaultChannel,
+		Speed:          1,
+		ReadOnly:       false,
+		RawMode:        false,
+		OtCliPath:      "./ot-cli-ftd",
+		Real:           false,
+		DispatcherHost: "localhost",
+		DispatcherPort: 9000,
 	}
 }

--- a/web/site/site.go
+++ b/web/site/site.go
@@ -36,7 +36,7 @@ import (
 	"github.com/simonlingoogle/go-simplelogger"
 )
 
-func Serve() error {
+func Serve(listenAddr string) error {
 	assetDir := os.Getenv("HOME")
 	if assetDir == "" {
 		assetDir = "/tmp"
@@ -83,5 +83,6 @@ func Serve() error {
 		}
 	})
 
-	return http.ListenAndServe("localhost:8997", nil)
+	simplelogger.Infof("OTNS web serving on %s ...", listenAddr)
+	return http.ListenAndServe(listenAddr, nil)
 }

--- a/web/site/site_test.go
+++ b/web/site/site_test.go
@@ -36,7 +36,7 @@ import (
 
 func TestServe(t *testing.T) {
 	go func() {
-		_ = Serve()
+		_ = Serve("localhost:8997")
 	}()
 	deadline := time.Now().Add(time.Second * 5)
 	for time.Now().Before(deadline) {


### PR DESCRIPTION
This PR enhances OTNS by adding a new `-listen` argument to specify listening address of OTNS. 

### Default (rejecting remote UDP events and HTTP connections):
```bash
$ otns -listen localhost:9000
```

### Allow OTNS to accept remote connections (UDP and HTTP)
```bash
$ otns -listen :9000
# or
$ otns -listen 0.0.0.0:9000
```

### Change ports
```bash
$ otns -listen "0.0.0.0:10000"
```

This also allows us to run multiple OTNS at the same time.
For example, we can run 3 OTNS instances simultaneously:
```
$ PORT_OFFSET=0 otns -listen :9000
$ PORT_OFFSET=1 otns -listen :10000
$ PORT_OFFSET=2 otns -listen :11000
```

![image](https://user-images.githubusercontent.com/52448427/88312748-1a8b5d80-cd45-11ea-8476-b31b828e4e02.png)
