### PR TITLE
[simulation] calculate PORT_OFFSET according to listen addr

### DIFF
--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -76,7 +76,7 @@ func DefaultConfig() *Config {
 		Speed: 1,
 		Real:  false,
 		Host:  "localhost",
-		Port:  9000,
+		Port:  threadconst.InitialDispatcherPort,
 	}
 }
 

--- a/otns_main/otns_main.go
+++ b/otns_main/otns_main.go
@@ -30,7 +30,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/openthread/ot-ns/threadconst"
 	"math/rand"
 	"os"
 	"os/signal"
@@ -38,6 +37,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/openthread/ot-ns/threadconst"
 
 	"github.com/openthread/ot-ns/dispatcher"
 

--- a/otns_main/otns_main.go
+++ b/otns_main/otns_main.go
@@ -30,6 +30,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/openthread/ot-ns/threadconst"
 	"math/rand"
 	"os"
 	"os/signal"
@@ -86,9 +87,37 @@ func parseArgs() {
 	flag.BoolVar(&args.OpenWeb, "web", true, "open web")
 	flag.BoolVar(&args.RawMode, "raw", false, "use raw mode")
 	flag.BoolVar(&args.Real, "real", false, "use real mode (for real devices)")
-	flag.StringVar(&args.ListenAddr, "listen", "localhost:9000", "specify listen address")
+	flag.StringVar(&args.ListenAddr, "listen", fmt.Sprintf("localhost:%d", threadconst.InitialDispatcherPort), "specify listen address")
 
 	flag.Parse()
+}
+
+func parseListenAddr() {
+	var err error
+
+	notifyInvalidListenAddr := func() {
+		simplelogger.Fatalf("invalid listen address: %s (port must be larger than or equal to 9000 and must be a multiple of 1000).", args.ListenAddr)
+	}
+
+	subs := strings.Split(args.ListenAddr, ":")
+	if len(subs) != 2 {
+		notifyInvalidListenAddr()
+	}
+
+	args.DispatcherHost = subs[0]
+	if args.DispatcherPort, err = strconv.Atoi(subs[1]); err != nil {
+		notifyInvalidListenAddr()
+	}
+
+	if args.DispatcherPort < threadconst.InitialDispatcherPort || args.DispatcherPort%threadconst.WellKnownNodeId != 0 {
+		notifyInvalidListenAddr()
+	}
+
+	portOffset := (args.DispatcherPort - threadconst.InitialDispatcherPort) / threadconst.WellKnownNodeId
+	simplelogger.Infof("Using env PORT_OFFSET=%d", portOffset)
+	if err = os.Setenv("PORT_OFFSET", strconv.Itoa(portOffset)); err != nil {
+		simplelogger.Panic(err)
+	}
 }
 
 func Main(visualizerCreator func(ctx *progctx.ProgCtx, args *MainArgs) visualize.Visualizer) {
@@ -96,15 +125,7 @@ func Main(visualizerCreator func(ctx *progctx.ProgCtx, args *MainArgs) visualize
 
 	simplelogger.SetLevel(simplelogger.ParseLevel(args.LogLevel))
 
-	var err error
-	subs := strings.Split(args.ListenAddr, ":")
-	if len(subs) != 2 {
-		simplelogger.Fatalf("invalid listen address: %s", args.ListenAddr)
-	}
-	args.DispatcherHost = subs[0]
-	if args.DispatcherPort, err = strconv.Atoi(subs[1]); err != nil {
-		simplelogger.Fatalf("invalid listen address: %s", args.ListenAddr)
-	}
+	parseListenAddr()
 
 	rand.Seed(time.Now().UnixNano())
 	// run console in the main goroutine

--- a/simulation/node.go
+++ b/simulation/node.go
@@ -30,7 +30,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"github.com/openthread/ot-ns/threadconst"
 	"io"
 	"io/ioutil"
 	"os"
@@ -39,6 +38,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/openthread/ot-ns/threadconst"
 
 	"github.com/openthread/ot-ns/otoutfilter"
 	. "github.com/openthread/ot-ns/types"

--- a/simulation/node.go
+++ b/simulation/node.go
@@ -30,6 +30,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"github.com/openthread/ot-ns/threadconst"
 	"io"
 	"io/ioutil"
 	"os"
@@ -63,7 +64,8 @@ const (
 func newNode(s *Simulation, id NodeId, cfg *NodeConfig) (*Node, error) {
 	var err error
 
-	flashFile := fmt.Sprintf("tmp/0_%d.flash", id)
+	portOffset := (s.cfg.DispatcherPort - threadconst.InitialDispatcherPort) / threadconst.WellKnownNodeId
+	flashFile := fmt.Sprintf("tmp/%d_%d.flash", portOffset, id)
 	if err := os.RemoveAll(flashFile); err != nil {
 		simplelogger.Errorf("Remove flash file %s failed: %+v", flashFile, err)
 	}

--- a/simulation/simulation_config.go
+++ b/simulation/simulation_config.go
@@ -26,6 +26,8 @@
 
 package simulation
 
+import "github.com/openthread/ot-ns/threadconst"
+
 const (
 	DefaultNetworkName = "OTSIM"
 	DefaultMasterKey   = "00112233445566778899aabbccddeeff"
@@ -59,6 +61,6 @@ func DefaultConfig() *Config {
 		OtCliPath:      "./ot-cli-ftd",
 		Real:           false,
 		DispatcherHost: "localhost",
-		DispatcherPort: 9000,
+		DispatcherPort: threadconst.InitialDispatcherPort,
 	}
 }

--- a/threadconst/threadconst.go
+++ b/threadconst/threadconst.go
@@ -29,4 +29,7 @@ package threadconst
 const (
 	InvalidRloc16   uint16 = 0xfffe
 	BroadcastRloc16 uint16 = 0xffff
+
+	WellKnownNodeId       = 1000
+	InitialDispatcherPort = 9000
 )


### PR DESCRIPTION
This PR enhances OTNS to calculate the correct PORT_OFFSET according to the specified listen address:

- [x] Calculate PORT_OFFSET according to listen port and install it to env. 
- [x] Remove correct `.flash` according to `PORT_OFFSET`

Now we don't need to specify PORT_OFFSET for OTNS:
```bash
$ otns -listen :12000  # use PORT_OFFSET=3 automatically 
```