### PR TITLE
[doc] add id arg to add CLI command README

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -7,7 +7,7 @@ Python libraries use the CLI to manage simulations.
 
 ## OTNS command list
 
-* [add](#add-type-x-x-y-y-rr-radio-range)
+* [add](#add-type-x-x-y-y-rr-radio-range-id-node-id)
 * [counters](#counters)
 * [cv](#cv-option-onoff-)
 * [del](#del-node-id-node-id-)
@@ -30,9 +30,9 @@ Python libraries use the CLI to manage simulations.
 ## OTNS command reference
 
 
-### add \<type\> \[x \<x\>\] \[y \<y\>\] \[rr \<radio-range\>\]
+### add \<type\> \[x \<x\>\] \[y \<y\>\] \[rr \<radio-range\>\] \[id \<node-id\>\]
 
-Add a node to the simulation and get the node ID. 
+Add a node to the simulation and get the node ID. Node ID can be specified, otherwise OTNS assigns the next available one.
 
 ```bash
 > add router
@@ -46,6 +46,9 @@ Done
 Done
 > add sed x 200 y 200 rr 400
 4
+Done
+> add fed x 200 y 200 id 25
+25
 Done
 ```
 


### PR DESCRIPTION
This commit fixes the issue where Node ID support for `add` CLI command is missing in README.