### PR TITLE
[ot-cli] kill ot-cli process with SIGTERM

### DIFF
--- a/simulation/node.go
+++ b/simulation/node.go
@@ -160,6 +160,7 @@ func (node *Node) Stop() {
 }
 
 func (node *Node) Exit() error {
+	node.inputCommand("exit")
 	_ = node.cmd.Process.Signal(syscall.SIGTERM)
 	_ = node.virtualUartReader.Close()
 

--- a/simulation/node.go
+++ b/simulation/node.go
@@ -37,6 +37,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/openthread/ot-ns/threadconst"
@@ -159,7 +160,7 @@ func (node *Node) Stop() {
 }
 
 func (node *Node) Exit() error {
-	_ = node.cmd.Process.Kill()
+	_ = node.cmd.Process.Signal(syscall.SIGTERM)
 	_ = node.virtualUartReader.Close()
 
 	err := node.cmd.Wait()


### PR DESCRIPTION
Coverage data was not generated from ot-cli-ftd when running otns. 
Turnout it was due to otns killing ot-cli-ftd using SIGKILL. 

Should use SIGTERM instead. 