### PR TITLE
[otnstester] adds initial otnstester tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-10.15]
+    env:
+      VIRTUAL_TIME_UART: 1
     steps:
       - uses: actions/setup-go@v1
         with:

--- a/cli/runner.go
+++ b/cli/runner.go
@@ -37,12 +37,10 @@ var (
 	contextLessCommandsPat = regexp.MustCompile(`(exit|node)\b`)
 )
 
-func Run(cr *CmdRunner) error {
+func Run(cr *CmdRunner, cliOptions *runcli.CliOptions) error {
 	defer simplelogger.Debugf("CLI exit")
 
-	return runcli.RunCli(cr, runcli.CliOptions{
-		EchoInput: false,
-	})
+	return runcli.RunCli(cr, cliOptions)
 }
 
 func isContextlessCommand(line string) bool {

--- a/cmd/otns/otns.go
+++ b/cmd/otns/otns.go
@@ -27,13 +27,18 @@
 package main
 
 import (
+	"context"
+	"os"
+
 	"github.com/openthread/ot-ns/otns_main"
 	"github.com/openthread/ot-ns/progctx"
 	"github.com/openthread/ot-ns/visualize"
 )
 
 func main() {
-	otns_main.Main(func(ctx *progctx.ProgCtx, args *otns_main.MainArgs) visualize.Visualizer {
+	ctx := progctx.New(context.Background())
+	otns_main.Main(ctx, func(ctx *progctx.ProgCtx, args *otns_main.MainArgs) visualize.Visualizer {
 		return nil
-	})
+	}, nil)
+	os.Exit(0)
 }

--- a/cmd/real/otns-silk-proxy/otns-silk-proxy.go
+++ b/cmd/real/otns-silk-proxy/otns-silk-proxy.go
@@ -27,7 +27,7 @@ func (c cliHandler) HandleCommand(cmd string, output io.Writer) error {
 }
 
 func main() {
-	err := runcli.RunCli(&cliHandler{}, runcli.CliOptions{
+	err := runcli.RunCli(&cliHandler{}, &runcli.CliOptions{
 		EchoInput: true,
 	})
 

--- a/otns_main/otns_main.go
+++ b/otns_main/otns_main.go
@@ -27,7 +27,6 @@
 package otns_main
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"math/rand"
@@ -37,6 +36,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/openthread/ot-ns/cli/runcli"
 
 	"github.com/openthread/ot-ns/threadconst"
 
@@ -126,7 +127,7 @@ func parseListenAddr() {
 	}
 }
 
-func Main(visualizerCreator func(ctx *progctx.ProgCtx, args *MainArgs) visualize.Visualizer) {
+func Main(ctx *progctx.ProgCtx, visualizerCreator func(ctx *progctx.ProgCtx, args *MainArgs) visualize.Visualizer, cliOptions *runcli.CliOptions) {
 	parseArgs()
 
 	simplelogger.SetLevel(simplelogger.ParseLevel(args.LogLevel))
@@ -135,7 +136,6 @@ func Main(visualizerCreator func(ctx *progctx.ProgCtx, args *MainArgs) visualize
 
 	rand.Seed(time.Now().UnixNano())
 	// run console in the main goroutine
-	ctx := progctx.New(context.Background())
 	ctx.Defer(func() {
 		_ = os.Stdin.Close()
 	})
@@ -163,7 +163,7 @@ func Main(visualizerCreator func(ctx *progctx.ProgCtx, args *MainArgs) visualize
 	sim.SetVisualizer(vis)
 	go sim.Run()
 	go func() {
-		err := cli.Run(rt)
+		err := cli.Run(rt, cliOptions)
 		ctx.Cancel(errors.Wrapf(err, "console exit"))
 	}()
 
@@ -190,7 +190,6 @@ func Main(visualizerCreator func(ctx *progctx.ProgCtx, args *MainArgs) visualize
 
 	simplelogger.Infof("waiting for OTNS to stop gracefully ...")
 	ctx.Wait()
-	os.Exit(0)
 }
 
 func handleSignals(ctx *progctx.ProgCtx) {

--- a/otnstester/OtnsTest.go
+++ b/otnstester/OtnsTest.go
@@ -1,0 +1,365 @@
+package otnstester
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	visualize_grpc_pb "github.com/openthread/ot-ns/visualize/grpc/pb"
+	"google.golang.org/grpc"
+
+	"github.com/openthread/ot-ns/dispatcher"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/chzyer/readline"
+	"github.com/openthread/ot-ns/cli/runcli"
+	"github.com/openthread/ot-ns/otns_main"
+	"github.com/openthread/ot-ns/progctx"
+	. "github.com/openthread/ot-ns/types"
+	"github.com/openthread/ot-ns/visualize"
+	"github.com/simonlingoogle/go-simplelogger"
+)
+
+var (
+	stdinPipeFile  = "stdin.namedpipe"
+	stdoutPipeFile = "stdout.namedpipe"
+)
+
+type OtnsTest struct {
+	*testing.T
+
+	stdin                  *os.File
+	stdout                 *os.File
+	otnsDone               chan struct{}
+	pendingOutput          chan string
+	pendingVisualizeEvents chan *visualize_grpc_pb.VisualizeEvent
+	stdinCloser            *readline.CancelableStdin
+	ctx                    *progctx.ProgCtx
+	grpcClient             visualize_grpc_pb.VisualizeGrpcServiceClient
+	visualizeStream        visualize_grpc_pb.VisualizeGrpcService_VisualizeClient
+}
+
+func (ot *OtnsTest) Go(duration time.Duration) {
+	seconds := float64(duration) / float64(time.Second)
+	ot.sendCommand(fmt.Sprintf("go %f", seconds))
+	ot.expectDone()
+}
+
+func (ot *OtnsTest) Join() {
+	<-ot.otnsDone
+}
+
+func (ot *OtnsTest) AddNode(role string) NodeId {
+	cmd := fmt.Sprintf("add %s", role)
+	ot.sendCommand(cmd)
+	return ot.expectCommandResultInt()
+}
+
+func (ot *OtnsTest) sendCommand(cmd string) {
+	simplelogger.Infof("> %s", cmd)
+	_, err := ot.stdin.WriteString(cmd + "\n")
+	simplelogger.PanicIfError(err)
+}
+
+func (ot *OtnsTest) sendCommandf(format string, args ...interface{}) {
+	cmd := fmt.Sprintf(format, args...)
+	ot.sendCommand(cmd)
+}
+
+func (ot *OtnsTest) stdoutReadRoutine() {
+	simplelogger.Infof("OTNS Stdout reader started.")
+
+	scanner := bufio.NewScanner(ot.stdout)
+	scanner.Split(bufio.ScanLines)
+
+	for scanner.Scan() {
+		simplelogger.Infof("read stdout: %#v", scanner.Text())
+		ot.pendingOutput <- scanner.Text()
+	}
+}
+
+func (ot *OtnsTest) shutdown() {
+
+}
+
+func (ot *OtnsTest) expectDone() {
+	ot.expectCommandResultLines()
+}
+
+func (ot *OtnsTest) expectCommandResultLines() (output []string) {
+loop:
+	for {
+		line := <-ot.pendingOutput
+
+		if line == "Done" {
+			break loop
+		} else if strings.HasPrefix(line, "Error") {
+			simplelogger.Panicf("%s", line)
+		} else {
+			output = append(output, line)
+		}
+	}
+
+	simplelogger.Infof("expectCommandResultLines: %#v", output)
+	return
+}
+
+func (ot *OtnsTest) expectCommandResultInt() int {
+	lines := ot.expectCommandResultLines()
+	simplelogger.AssertTrue(len(lines) == 1)
+
+	v, err := strconv.Atoi(lines[0])
+	simplelogger.PanicIfError(err)
+
+	return v
+}
+
+func (ot *OtnsTest) Shutdown() {
+	ot.ctx.Cancel(nil)
+	ot.Join()
+}
+
+func (ot *OtnsTest) SetSpeed(speed int) {
+	ot.sendCommandf("speed %d", speed)
+	ot.expectDone()
+}
+
+func (ot *OtnsTest) Reset() {
+	ot.SetSpeed(dispatcher.MaxSimulateSpeed)
+	ot.SetPacketLossRatio(0)
+	ot.RemoveAllNodes()
+}
+
+func (ot *OtnsTest) SetPacketLossRatio(ratio float32) {
+	ot.sendCommandf("plr %f", ratio)
+	ot.expectDone()
+}
+
+func (ot *OtnsTest) RemoveAllNodes() {
+	nodes := ot.ListNodes()
+	simplelogger.Infof("Remove all nodes: %+v", nodes)
+	for nodeid := range nodes {
+		ot.DeleteNode(nodeid)
+	}
+}
+
+type NodeInfo struct {
+	ExtAddr uint64
+	Rloc16  uint16
+	X, Y    int
+	Failed  bool
+}
+
+func (ot *OtnsTest) ListNodes() map[NodeId]*NodeInfo {
+	ot.sendCommand("nodes")
+	lines := ot.expectCommandResultLines()
+	nodes := map[NodeId]*NodeInfo{}
+
+	for _, line := range lines {
+		var err error
+		var id NodeId
+		var extaddr uint64
+		var rloc16 uint16
+		var x, y int
+		failed := false
+
+		for _, sec := range strings.Split(line, "\t") {
+			kv := strings.Split(sec, "=")
+
+			switch kv[0] {
+			case "id":
+				id, err = strconv.Atoi(kv[1])
+				ot.ExpectNoError(err)
+			case "extaddr":
+				extaddr, err = strconv.ParseUint(kv[1], 16, 64)
+				ot.ExpectNoError(err)
+			case "rloc16":
+				var value uint64
+				value, err = strconv.ParseUint(kv[1], 16, 16)
+				ot.ExpectNoError(err)
+				rloc16 = uint16(value)
+			case "x":
+				x, err = strconv.Atoi(kv[1])
+				ot.ExpectNoError(err)
+			case "y":
+				y, err = strconv.Atoi(kv[1])
+				ot.ExpectNoError(err)
+			case "failed":
+				ot.ExpectTrue(kv[1] == "false" || kv[1] == "true")
+				failed = kv[1] == "failed"
+			}
+		}
+		nodes[id] = &NodeInfo{
+			ExtAddr: extaddr,
+			Rloc16:  rloc16,
+			X:       x,
+			Y:       y,
+			Failed:  failed,
+		}
+	}
+
+	return nodes
+}
+
+func (ot *OtnsTest) ExpectNoError(err error) {
+	assert.Nil(ot, err, "unexpected error")
+	if err != nil {
+		ot.FailNow()
+	}
+}
+
+func (ot *OtnsTest) ExpectTrue(value bool, msgAndArgs ...interface{}) {
+	assert.True(ot, value, msgAndArgs...)
+
+	if !value {
+		ot.FailNow()
+	}
+}
+
+func (ot *OtnsTest) DeleteNode(ids ...NodeId) {
+	if len(ids) == 0 {
+		return
+	}
+
+	cmd := "del"
+	for _, id := range ids {
+		cmd = cmd + fmt.Sprintf(" %d", id)
+	}
+	ot.executeCommand(cmd)
+}
+
+func (ot *OtnsTest) executeCommand(cmd string) []string {
+	ot.sendCommand(cmd)
+	return ot.expectCommandResultLines()
+}
+
+func (ot *OtnsTest) GetNodeState(id NodeId) string {
+	lines := ot.executeCommandNodeContext(id, "state")
+	ot.ExpectTrue(len(lines) == 1)
+	return lines[0]
+}
+
+func (ot *OtnsTest) executeCommandNodeContext(id NodeId, cmd string) []string {
+	return ot.executeCommand(fmt.Sprintf("node %d \"%s\"", id, cmd))
+}
+
+func (ot *OtnsTest) Command(cmd string) []string {
+	ot.sendCommand(cmd)
+	return ot.expectCommandResultLines()
+}
+
+func (ot *OtnsTest) Commandf(format string, args ...interface{}) []string {
+	ot.sendCommandf(format, args...)
+	return ot.expectCommandResultLines()
+}
+
+func (ot *OtnsTest) visualizeStreamReadRoutine() {
+	vctx := ot.visualizeStream.Context()
+
+	for vctx.Err() == nil {
+		evt, err := ot.visualizeStream.Recv()
+
+		ot.ExpectTrue(err == nil || ot.visualizeStream.Context().Err() != nil)
+		if err == nil {
+			simplelogger.Warnf("Visualize: %+v", evt)
+			ot.pendingVisualizeEvents <- evt
+		}
+	}
+}
+
+func (ot *OtnsTest) ExpectVisualizeEvent(match func(evt *visualize_grpc_pb.VisualizeEvent) bool) {
+	deadline := time.After(time.Second * 10)
+	for {
+		select {
+		case evt := <-ot.pendingVisualizeEvents:
+			if match(evt) {
+				return
+			}
+		case <-deadline:
+			ot.ExpectTrue(false, "ExpectVisualizeEvent timeout")
+		}
+	}
+}
+
+func (ot *OtnsTest) ExpectVisualizeAddNode(nodeid NodeId, x int, y int, radioRange int) {
+	ot.ExpectVisualizeEvent(func(evt *visualize_grpc_pb.VisualizeEvent) bool {
+		addNode := evt.GetAddNode()
+		if addNode == nil {
+			return false
+		}
+
+		return addNode.NodeId == int32(nodeid) && addNode.X == int32(x) && addNode.Y == int32(y) && addNode.RadioRange == int32(radioRange)
+	})
+}
+
+func NewOtnsTest(t *testing.T) *OtnsTest {
+	ot := &OtnsTest{
+		T:                      t,
+		otnsDone:               make(chan struct{}),
+		pendingOutput:          make(chan string, 1000),
+		pendingVisualizeEvents: make(chan *visualize_grpc_pb.VisualizeEvent, 1000),
+	}
+
+	os.Args = append(os.Args, "-log", "debug", "-web=false", "-autogo=false")
+
+	_ = os.Remove(stdinPipeFile)
+	_ = os.Remove(stdoutPipeFile)
+
+	err := syscall.Mkfifo(stdinPipeFile, 0644)
+	simplelogger.PanicIfError(err)
+
+	ot.stdin, err = os.OpenFile(stdinPipeFile, os.O_RDWR, os.ModeNamedPipe)
+	simplelogger.PanicIfError(err)
+	ot.stdinCloser = readline.NewCancelableStdin(ot.stdin)
+
+	err = syscall.Mkfifo(stdoutPipeFile, 0644)
+	simplelogger.PanicIfError(err)
+
+	ot.stdout, err = os.OpenFile(stdoutPipeFile, os.O_RDWR, os.ModeNamedPipe)
+	simplelogger.PanicIfError(err)
+
+	ot.ctx = progctx.New(context.Background())
+
+	go func() {
+		defer func() {
+			simplelogger.Infof("OTNS exited.")
+			ot.shutdown()
+			close(ot.otnsDone)
+		}()
+
+		otns_main.Main(ot.ctx, func(ctx *progctx.ProgCtx, args *otns_main.MainArgs) visualize.Visualizer {
+			return nil
+		}, &runcli.CliOptions{
+			EchoInput: false,
+			Stdin:     ot.stdin,
+			Stdout:    ot.stdout,
+		})
+	}()
+
+	grpcConn, err := grpc.Dial("localhost:8999", grpc.WithInsecure())
+	ot.ExpectNoError(err)
+
+	grpcClient := visualize_grpc_pb.NewVisualizeGrpcServiceClient(grpcConn)
+	ot.grpcClient = grpcClient
+
+	deadline := time.Now().Add(time.Second * 10)
+	for time.Now().Before(deadline) {
+		visualizeStream, err := grpcClient.Visualize(ot.ctx, &visualize_grpc_pb.VisualizeRequest{})
+		if err != nil {
+			continue
+		}
+
+		ot.visualizeStream = visualizeStream
+		break
+	}
+
+	go ot.stdoutReadRoutine()
+	go ot.visualizeStreamReadRoutine()
+	return ot
+}

--- a/otnstester/OtnsTest.go
+++ b/otnstester/OtnsTest.go
@@ -1,3 +1,29 @@
+// Copyright (c) 2020, The OTNS Authors.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the
+//    names of its contributors may be used to endorse or promote products
+//    derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 package otnstester
 
 import (

--- a/otnstester/tests/consts.go
+++ b/otnstester/tests/consts.go
@@ -1,3 +1,29 @@
+// Copyright (c) 2020, The OTNS Authors.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the
+//    names of its contributors may be used to endorse or promote products
+//    derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 package main
 
 import "github.com/openthread/ot-ns/simulation"

--- a/otnstester/tests/consts.go
+++ b/otnstester/tests/consts.go
@@ -1,0 +1,13 @@
+package main
+
+import "github.com/openthread/ot-ns/simulation"
+
+const (
+	RoleLeader = "leader"
+	RoleRouter = "router"
+	RoleChild  = "child"
+)
+
+var (
+	DefaultRadioRange = simulation.DefaultNodeConfig().RadioRange
+)

--- a/otnstester/tests/otns_basic_test.go
+++ b/otnstester/tests/otns_basic_test.go
@@ -1,3 +1,29 @@
+// Copyright (c) 2020, The OTNS Authors.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the
+//    names of its contributors may be used to endorse or promote products
+//    derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 package main
 
 import (

--- a/otnstester/tests/otns_basic_test.go
+++ b/otnstester/tests/otns_basic_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openthread/ot-ns/otnstester"
+)
+
+func TestAdd(t *testing.T) {
+	ot := otnstester.NewOtnsTest(t)
+
+	defer ot.Shutdown()
+
+	testAddNode(ot)
+}
+
+func testAddNode(test *otnstester.OtnsTest) {
+	test.Reset()
+
+	nodeid := test.AddNode("router")
+	test.ExpectTrue(nodeid == 1)
+	test.Go(time.Second * 3)
+	test.ExpectTrue(test.GetNodeState(nodeid) == RoleLeader)
+	test.ExpectVisualizeAddNode(nodeid, 0, 0, DefaultRadioRange)
+
+	router2 := test.AddNode("router")
+	test.ExpectTrue(router2 == 2)
+	test.Go(time.Second * 10)
+	test.ExpectTrue(test.GetNodeState(router2) == RoleRouter)
+	test.ExpectVisualizeAddNode(router2, 0, 0, DefaultRadioRange)
+
+	test.Command("add fed x 50 y 60")
+	fed := 3
+	test.Go(time.Second * 10)
+	test.ExpectTrue(test.GetNodeState(fed) == RoleChild)
+	test.ExpectVisualizeAddNode(fed, 50, 60, DefaultRadioRange)
+
+	fedInfo := test.ListNodes()[fed]
+	test.ExpectTrue(fedInfo.X == 50)
+	test.ExpectTrue(fedInfo.Y == 60)
+
+	test.Command("add med x 10 y 20 rr 100")
+	med := 4
+	test.Go(time.Second * 10)
+	test.ExpectTrue(test.GetNodeState(med) == RoleChild)
+	test.ExpectVisualizeAddNode(med, 10, 20, 100)
+
+	medInfo := test.ListNodes()[med]
+	test.ExpectTrue(medInfo.X == 10)
+	test.ExpectTrue(medInfo.Y == 20)
+
+	test.Command("add sed x 30 y 40")
+	sed := 5
+	test.Go(time.Second * 10)
+	test.ExpectTrue(test.GetNodeState(sed) == RoleChild)
+	test.ExpectVisualizeAddNode(sed, 30, 40, DefaultRadioRange)
+	sedInfo := test.ListNodes()[sed]
+	test.ExpectTrue(sedInfo.X == 30)
+	test.ExpectTrue(sedInfo.Y == 40)
+}

--- a/script/test
+++ b/script/test
@@ -47,12 +47,14 @@ go_tests()
     install_deps
     install_otns
 
+    build_openthread
+
     echo "" >coverage.txt
 
     PKG=$(go list ./...)
 
     for d in $PKG; do
-        go test -race -coverprofile=profile.out -covermode=atomic "$d"
+        OTNS_OT_CLI=$OTBIN_DIR/ot-cli-ftd go test -race -coverprofile=profile.out -covermode=atomic -coverpkg=./... "$d"
         if [ -f profile.out ]; then
             cat profile.out >>coverage.txt
             rm profile.out


### PR DESCRIPTION
This PR adds the `otnstester` and some initial tests. 

**Background:**
In Golang, only Go tests executed as `go test` are able to collect code coverage. Because of it, code coverage of `pyOTNS` tests can not  be measured by `Codecov.io`. 

The `otnstester` wraps the whole `OTNS` program into a Go test so that we can build tests and collect code coverage data for all OTNS functionalities. 