### PR TITLE
[dispatcher] dump radio packets to STDOUT

### DIFF
--- a/otns_main/otns_main.go
+++ b/otns_main/otns_main.go
@@ -73,6 +73,7 @@ type MainArgs struct {
 	ListenAddr     string
 	DispatcherHost string
 	DispatcherPort int
+	DumpPackets    bool
 }
 
 var (
@@ -94,6 +95,7 @@ func parseArgs() {
 	flag.BoolVar(&args.RawMode, "raw", false, "use raw mode")
 	flag.BoolVar(&args.Real, "real", false, "use real mode (for real devices)")
 	flag.StringVar(&args.ListenAddr, "listen", fmt.Sprintf("localhost:%d", threadconst.InitialDispatcherPort), "specify listen address")
+	flag.BoolVar(&args.DumpPackets, "dump-packets", false, "dump packets")
 
 	flag.Parse()
 }
@@ -241,6 +243,7 @@ func createSimulation(ctx *progctx.ProgCtx) *simulation.Simulation {
 	simcfg.Real = args.Real
 	simcfg.DispatcherHost = args.DispatcherHost
 	simcfg.DispatcherPort = args.DispatcherPort
+	simcfg.DumpPackets = args.DumpPackets
 
 	sim, err := simulation.NewSimulation(ctx, simcfg)
 	simplelogger.FatalIfError(err)

--- a/simulation/simulation.go
+++ b/simulation/simulation.go
@@ -67,6 +67,7 @@ func NewSimulation(ctx *progctx.ProgCtx, cfg *Config) (*Simulation, error) {
 	dispatcherCfg.Real = cfg.Real
 	dispatcherCfg.Host = cfg.DispatcherHost
 	dispatcherCfg.Port = cfg.DispatcherPort
+	dispatcherCfg.DumpPackets = cfg.DumpPackets
 
 	s.d = dispatcher.NewDispatcher(s.ctx, dispatcherCfg, s)
 	s.vis = s.d.GetVisualizer()

--- a/simulation/simulation_config.go
+++ b/simulation/simulation_config.go
@@ -47,6 +47,7 @@ type Config struct {
 	Real           bool
 	DispatcherHost string
 	DispatcherPort int
+	DumpPackets    bool
 }
 
 func DefaultConfig() *Config {


### PR DESCRIPTION
This PR adds the `-dump-packets` (default: false) argument to `otns`.

If `-dump-packets` is on, OTNS dumps raw radio packets via STDOUT. 
 
```
> go 100
DUMP:PACKET:11549279961:1:0B41D8C7CEFAFFFF11346B5760F6710E7F3B01F04D4C4D4C4BE00015A10100000000000001BD8BF63F0A0A6AF8C992C8841A6E3C7EC2827F41B359781FF8ED1028BAC4E5A1FD
DUMP:PACKET:11568497962:2:0B61DC8FCEFA11346B5760F6710EA40ED4AF4305979A7F33F04D4C4D4C2876001547000000000000000149E8EE7BFD307626853CFE5B1F56832FA18AF7828FA174C58F20CA9D2ABC
DUMP:PACKET:11568497963:1:0B12108F43D9
DUMP:PACKET:11568500203:1:0B61DCC8CEFAA40ED4AF4305979A11346B5760F6710E7F33F04D4C4D4C279B0015A201000000000000019654ADA16ED62B9840600A79B232366283E755A80DFD9CDDDC0A306AF7CF
DUMP:PACKET:11568500204:2:0B1210C8F8EF
DUMP:PACKET:11574944125:1:0B41D8C9CEFAFFFF11346B5760F6710E7F3B01F04D4C4D4C372C0015A301000000000000018B265505BBCF250745AD2BB18C27E57E57D833D74372D5E629689F7A8F0A3B5504
DUMP:PACKET:11609088366:1:0B41D8CACEFAFFFF11346B5760F6710E7F3B01F04D4C4D4CBB050015A40100000000000001791747F83FF00139000C18B1B37981CF80546B911861112FD88C70A9BB8C98C329
Done
```

**This feature is useful for using OTNS as thread-cert virtual time simulator in OpenThread CI**