### PR TITLE
[simulation] enhance to work with OpenThread simulation CI

### DIFF
--- a/cli/CmdRunner.go
+++ b/cli/CmdRunner.go
@@ -173,6 +173,8 @@ func (rt *CmdRunner) execute(cmd *Command, output io.Writer) {
 		rt.executeRadio(cc, cc.Radio)
 	} else if cmd.Go != nil {
 		rt.executeGo(cc, cmd.Go)
+	} else if cmd.Now != nil {
+		rt.executeNow(cc, cmd.Now)
 	} else if cmd.Nodes != nil {
 		rt.executeLsNodes(cc, cc.Nodes)
 	} else if cmd.Partitions != nil {
@@ -222,10 +224,17 @@ func (rt *CmdRunner) execute(cmd *Command, output io.Writer) {
 
 func (rt *CmdRunner) executeGo(cc *CommandContext, cmd *GoCmd) {
 	if cmd.Speed != nil {
-		rt.postAsyncWait(func(sim *simulation.Simulation) {
-			sim.SetSpeed(*cmd.Speed)
+		rt.sim.PostAsync(false, func() {
+			rt.sim.SetSpeed(*cmd.Speed)
 		})
 	}
+
+	if cmd.NodeId != nil {
+		rt.sim.PostAsync(false, func() {
+			rt.sim.Dispatcher().NotifyRunning(cmd.NodeId.Id)
+		})
+	}
+
 	var done <-chan struct{}
 
 	if cmd.Ever == nil {
@@ -295,6 +304,9 @@ func (rt *CmdRunner) executeAddNode(cc *CommandContext, cmd *AddCmd) {
 		cfg.IsRouter = false
 		cfg.IsMtd = true
 		cfg.RxOffWhenIdle = true
+	} else if cmd.Type.Val == "raw" {
+		cfg.IsRaw = true
+		cfg.IsRouter = false
 	} else {
 		panic("wrong node type")
 	}
@@ -312,6 +324,14 @@ func (rt *CmdRunner) executeAddNode(cc *CommandContext, cmd *AddCmd) {
 	}
 
 	cfg.Restore = cmd.Restore != nil
+
+	if cmd.UartType != nil && cmd.UartType.Val != "auto" {
+		if cmd.UartType.Val == "virtual" {
+			cfg.UartType = simulation.NodeUartTypeVirtualTime
+		} else {
+			cfg.UartType = simulation.NodeUartTypeRealTime
+		}
+	}
 
 	rt.postAsyncWait(func(sim *simulation.Simulation) {
 		node, err := sim.AddNode(cfg)
@@ -767,6 +787,12 @@ func (rt *CmdRunner) executeCoaps(cc *CommandContext, cmd *CoapsCmd) {
 
 		cc.outputItemsAsYaml(coapMessages)
 	}
+}
+
+func (rt *CmdRunner) executeNow(cc *CommandContext, cmd *NowCmd) {
+	rt.postAsyncWait(func(sim *simulation.Simulation) {
+		cc.outputf("%d\n", sim.Dispatcher().CurTime)
+	})
 }
 
 func NewCmdRunner(ctx *progctx.ProgCtx, sim *simulation.Simulation) *CmdRunner {

--- a/cli/ast.go
+++ b/cli/ast.go
@@ -51,6 +51,7 @@ type Command struct {
 	NetInfo             *NetInfoCmd             `| @@` //nolint
 	Node                *NodeCmd                `| @@` //nolint
 	Nodes               *NodesCmd               `| @@` //nolint
+	Now                 *NowCmd                 `| @@` //nolint
 	Partitions          *PartitionsCmd          `| @@` //nolint
 	Ping                *PingCmd                `| @@` //nolint
 	Pings               *PingsCmd               `| @@` //nolint
@@ -98,10 +99,17 @@ type DebugCmd struct {
 
 //noinspection GoStructTag
 type GoCmd struct {
-	Cmd     struct{}  `"go"`                      //nolint
-	Seconds float64   `( (@Int|@Float)`           //nolint
-	Ever    *EverFlag `| @@ )`                    //nolint
-	Speed   *float64  `[ "speed" (@Int|@Float) ]` //nolint
+	Cmd     struct{}    `"go"`                      //nolint
+	Seconds float64     `( (@Int|@Float)`           //nolint
+	Ever    *EverFlag   `| @@ )`                    //nolint
+	Speed   *float64    `( ("speed" (@Int|@Float))` //nolint
+	NodeId  *NodeIdFlag `| @@ )*`                   //nolint
+}
+
+//noinspection GoStructTag
+type NodeIdFlag struct {
+	Flag struct{} `"node"` //nolint
+	Id   int      `@Int`   //nolint
 }
 
 //noinspection GoStructTag
@@ -257,7 +265,8 @@ type AddCmd struct {
 	Id         *AddNodeId      `| @@`                 //nolint
 	RadioRange *RadioRangeFlag `| @@`                 //nolint
 	Restore    *RestoreFlag    `| @@`                 //nolint
-	Executable *ExecutableFlag `| @@ )*`              //nolint
+	Executable *ExecutableFlag `| @@`                 //nolint
+	UartType   *UartTypeFlag   `| @@ )*`              //nolint
 }
 
 //noinspection GoStructTag
@@ -276,6 +285,12 @@ type ExecutableFlag struct {
 	Path  string   `@String` //nolint
 }
 
+//noinspection GoStructTag
+type UartTypeFlag struct {
+	Dummy struct{} `"uart"`                     //nolint
+	Val   string   `@("virtual"|"real"|"auto")` //nolint
+}
+
 //noinspection MaxSpeedFlag
 type MaxSpeedFlag struct {
 	Dummy struct{} `( "max" | "inf")` //nolint
@@ -283,7 +298,7 @@ type MaxSpeedFlag struct {
 
 //noinspection GoStructTag
 type NodeType struct {
-	Val string `@("router"|"fed"|"med"|"sed")` //nolint
+	Val string `@("router"|"fed"|"med"|"sed"|"raw")` //nolint
 }
 
 //noinspection GoStructTag
@@ -379,6 +394,11 @@ type Move struct {
 //noinspection GoStructTag
 type NodesCmd struct {
 	Cmd struct{} `"nodes"` //nolint
+}
+
+//noinspection GoStructTag
+type NowCmd struct {
+	Cmd struct{} `"now"` //nolint
 }
 
 //noinspection GoStructTag

--- a/cmd/otns-otci-proxy/otns-otci-proxy.go
+++ b/cmd/otns-otci-proxy/otns-otci-proxy.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"io"
+	"os"
+
+	"github.com/pkg/errors"
+
+	"github.com/openthread/ot-ns/cli/runcli"
+	"github.com/simonlingoogle/go-simplelogger"
+)
+
+type cliHandler struct{}
+
+func (c cliHandler) GetPrompt() string {
+	return "> "
+}
+
+func (c cliHandler) HandleCommand(cmd string, output io.Writer) error {
+	if _, err := output.Write([]byte("Done\n")); err != nil {
+		return err
+	}
+
+	if cmd == "exit" {
+		os.Exit(0)
+	} else {
+		panic(errors.Errorf("can not handle other command"))
+	}
+
+	return nil
+}
+
+func main() {
+	err := runcli.RunCli(&cliHandler{}, &runcli.CliOptions{
+		EchoInput: true,
+	})
+
+	if err != nil {
+		simplelogger.Error(err)
+	}
+}

--- a/dispatcher/Node.go
+++ b/dispatcher/Node.go
@@ -99,9 +99,15 @@ func newNode(d *Dispatcher, nodeid NodeId, x, y int, radioRange int) *Node {
 		ExtAddr:     InvalidExtAddr,
 		Rloc16:      threadconst.InvalidRloc16,
 		Role:        OtDeviceRoleDisabled,
-		peerAddr:    nil, // peer address will be set when the first event is received
 		radioRange:  radioRange,
 		joinerState: OtJoinerStateIdle,
+	}
+
+	// If the dispatcher is listening on localhost, the peer address can be calculated from `nodeid`
+	if d.cfg.Host == "localhost" || d.cfg.Host == "127.0.0.1" {
+		var err error
+		nc.peerAddr, err = net.ResolveUDPAddr("udp4", fmt.Sprintf("%s:%d", d.cfg.Host, d.cfg.Port+nodeid))
+		simplelogger.PanicIfError(err)
 	}
 
 	nc.failureCtrl = newFailureCtrl(nc, NonFailTime)

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -299,7 +299,7 @@ func (d *Dispatcher) handleRecvEvent(evt *event) {
 	if _, ok := d.nodes[nodeid]; !ok {
 		if _, deleted := d.deletedNodes[nodeid]; !deleted {
 			// can not find the node, and the node is not registered (created by OTNS)
-			simplelogger.Warnf("unexpect event (type %v) received from Node %v", evt.Type, evt.NodeId)
+			simplelogger.Warnf("unexpected event (type %v) received from Node %v: %+v", evt.Type, evt.NodeId, evt)
 		}
 
 		return
@@ -886,20 +886,29 @@ func (d *Dispatcher) AddNode(nodeid NodeId, x, y int, radioRange int) {
 	node := d.newNode(nodeid, x, y, radioRange)
 
 	if !d.cfg.Real {
-		// Wait until node's extended address is emitted (but not for real devices)
+		// Wait until node's first simulation event is received (but not for real devices)
 		// This helps OTNS to make sure that the child process is ready to receive UDP events
-		t0 := time.Now()
-		deadline := t0.Add(time.Second * 10)
-		for node.ExtAddr == InvalidExtAddr && time.Now().Before(deadline) {
-			d.RecvEvents()
-		}
+		d.expectAnyNodeEvent(node)
+	}
+}
 
-		if node.ExtAddr == InvalidExtAddr {
-			simplelogger.Panicf("expect node %d's extaddr to be valid, but failed", nodeid)
-		} else {
-			takeTime := time.Since(t0)
-			simplelogger.Debugf("node %d's extaddr becomes valid in %v", nodeid, takeTime)
-		}
+func (d *Dispatcher) expectAnyNodeEvent(node *Node) {
+	if node.peerAddr != nil {
+		return
+	}
+
+	t0 := time.Now()
+	deadline := t0.Add(time.Second * 10)
+
+	for node.peerAddr == nil && time.Now().Before(deadline) {
+		d.RecvEvents()
+	}
+
+	if node.peerAddr == nil {
+		simplelogger.Panicf("waiting for simulation event from node %d, but failed", node.Id)
+	} else {
+		takeTime := time.Since(t0)
+		simplelogger.Debugf("node %d's first simulation event arrive in %v", node.Id, takeTime)
 	}
 }
 
@@ -1316,4 +1325,8 @@ func (d *Dispatcher) CollectCoapMessages() []*CoapMessage {
 	} else {
 		return nil
 	}
+}
+
+func (d *Dispatcher) NotifyRunning(nodeid NodeId) {
+	d.setAlive(nodeid)
 }

--- a/simulation/node.go
+++ b/simulation/node.go
@@ -67,7 +67,7 @@ func newNode(s *Simulation, id NodeId, cfg *NodeConfig) (*Node, error) {
 	var err error
 
 	if !cfg.Restore {
-		portOffset := (s.cfg.DispatcherPort - threadconst.InitialDispatcherPort) / threadconst.WellKnownNodeId
+		portOffset := (s.cfg.DispatcherPort - threadconst.InitialDispatcherPort) / s.cfg.WellKnownNodeId
 		flashFile := fmt.Sprintf("tmp/%d_%d.flash", portOffset, id)
 		if err := os.RemoveAll(flashFile); err != nil {
 			simplelogger.Errorf("Remove flash file %s failed: %+v", flashFile, err)
@@ -87,7 +87,6 @@ func newNode(s *Simulation, id NodeId, cfg *NodeConfig) (*Node, error) {
 		cfg:          cfg,
 		cmd:          cmd,
 		pendingLines: make(chan string, 100),
-		uartType:     NodeUartTypeUndefined,
 	}
 
 	node.virtualUartReader, node.virtualUartPipe = io.Pipe()
@@ -129,7 +128,6 @@ type Node struct {
 	pipeErr           io.ReadCloser
 	virtualUartReader *io.PipeReader
 	virtualUartPipe   *io.PipeWriter
-	uartType          NodeUartType
 }
 
 func (node *Node) String() string {
@@ -188,9 +186,9 @@ func (node *Node) AssurePrompt() {
 }
 
 func (node *Node) inputCommand(cmd string) {
-	simplelogger.AssertTrue(node.uartType != NodeUartTypeUndefined)
+	simplelogger.AssertTrue(node.cfg.UartType != NodeUartTypeUndefined)
 
-	if node.uartType == NodeUartTypeRealTime {
+	if node.cfg.UartType == NodeUartTypeRealTime {
 		_, _ = node.pipeIn.Write([]byte(cmd + "\n"))
 		node.S.Dispatcher().NotifyCommand(node.Id)
 	} else {
@@ -593,9 +591,9 @@ func (node *Node) lineReader(reader io.Reader, uartType NodeUartType) {
 	for scanner.Scan() {
 		line := scanner.Text()
 
-		if node.uartType == NodeUartTypeUndefined {
+		if node.cfg.UartType == NodeUartTypeUndefined {
 			simplelogger.Debugf("%v's UART type is %v", node, uartType)
-			node.uartType = uartType
+			node.cfg.UartType = uartType
 		}
 
 		select {
@@ -700,6 +698,13 @@ func (node *Node) DumpStat() string {
 }
 
 func (node *Node) setupMode() {
+	if node.cfg.IsRaw {
+		// raw nodes should not set other flags
+		simplelogger.AssertFalse(node.cfg.IsRouter)
+		simplelogger.AssertFalse(node.cfg.IsMtd)
+		simplelogger.AssertFalse(node.cfg.RxOffWhenIdle)
+	}
+
 	if node.cfg.IsRouter {
 		// routers should be full functional and rx always on
 		simplelogger.AssertFalse(node.cfg.IsMtd)
@@ -709,21 +714,24 @@ func (node *Node) setupMode() {
 	// only MED can use RxOffWhenIdle
 	simplelogger.AssertTrue(!node.cfg.RxOffWhenIdle || node.cfg.IsMtd)
 
-	mode := ""
-	if !node.cfg.RxOffWhenIdle {
-		mode += "r"
-	}
-	if !node.cfg.IsMtd {
-		mode += "d"
-	}
-	mode += "n"
+	if !node.cfg.IsRaw {
+		mode := ""
+		if !node.cfg.RxOffWhenIdle {
+			mode += "r"
+		}
+		mode += "s"
+		if !node.cfg.IsMtd {
+			mode += "d"
+		}
+		mode += "n"
 
-	node.SetMode(mode)
+		node.SetMode(mode)
 
-	if !node.cfg.IsRouter {
-		node.RouterEligibleDisable()
-	} else {
-		node.SetRouterSelectionJitter(1)
+		if !node.cfg.IsRouter {
+			node.RouterEligibleDisable()
+		} else {
+			node.SetRouterSelectionJitter(1)
+		}
 	}
 }
 
@@ -733,10 +741,14 @@ func (node *Node) onUartWrite(data []byte) {
 
 func (node *Node) detectVirtualTimeUART() {
 	// Input newline to both Virtual Time UART and stdin and check where node outputs newline
+	if node.cfg.UartType != NodeUartTypeUndefined {
+		return
+	}
+
 	node.S.Dispatcher().SendToUART(node.Id, []byte("\n"))
 	_, _ = node.pipeIn.Write([]byte("\n"))
 
 	node.expectLine("", DefaultCommandTimeout)
 	// UART type should have been correctly set when the new line is received from node
-	simplelogger.AssertTrue(node.uartType != NodeUartTypeUndefined)
+	simplelogger.AssertTrue(node.cfg.UartType != NodeUartTypeUndefined)
 }

--- a/simulation/node_config.go
+++ b/simulation/node_config.go
@@ -29,12 +29,14 @@ package simulation
 type NodeConfig struct {
 	ID             int
 	X, Y           int
+	IsRaw          bool
 	IsMtd          bool
 	IsRouter       bool
 	RxOffWhenIdle  bool
 	RadioRange     int
 	ExecutablePath string
 	Restore        bool
+	UartType       NodeUartType
 }
 
 func DefaultNodeConfig() *NodeConfig {
@@ -42,6 +44,7 @@ func DefaultNodeConfig() *NodeConfig {
 		ID:             -1, // -1 for the next available nodeid
 		X:              0,
 		Y:              0,
+		IsRaw:          false,
 		IsRouter:       true,
 		IsMtd:          false,
 		RxOffWhenIdle:  false,

--- a/simulation/simulation.go
+++ b/simulation/simulation.go
@@ -110,7 +110,7 @@ func (s *Simulation) AddNode(cfg *NodeConfig) (*Node, error) {
 
 	node.setupMode()
 
-	if !s.rawMode {
+	if !s.rawMode && !node.cfg.IsRaw {
 		node.SetupNetworkParameters(s)
 		node.Start()
 	}

--- a/simulation/simulation_config.go
+++ b/simulation/simulation_config.go
@@ -36,18 +36,19 @@ const (
 )
 
 type Config struct {
-	NetworkName    string
-	NetworkKey     string
-	Panid          uint16
-	Channel        int
-	OtCliPath      string
-	Speed          float64
-	ReadOnly       bool
-	RawMode        bool
-	Real           bool
-	DispatcherHost string
-	DispatcherPort int
-	DumpPackets    bool
+	NetworkName     string
+	NetworkKey       string
+	Panid           uint16
+	Channel         int
+	OtCliPath       string
+	Speed           float64
+	ReadOnly        bool
+	RawMode         bool
+	Real            bool
+	DispatcherHost  string
+	DispatcherPort  int
+	DumpPackets     bool
+	WellKnownNodeId int
 }
 
 func DefaultConfig() *Config {


### PR DESCRIPTION
This PR includes several enhancements to OTNS so that it can be used as a virtual time simulator in OpenThread simulation CI. 
 - add otns-otci-proxy
 - allow configure WellKnownNodeId
 - no need to wait for `extaddr` event if running locally
 - CLI enhancements
   - add new node type `raw` to `add` command
   - allow specify uart type in `add` command
   - add `now` command
   - add argument `node <id>` to `go` command