### PR TITLE
[github-actions] fix brew update warning

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -40,6 +40,8 @@ jobs:
   develop:
     name: Develop (Go${{ matrix.go }},Py${{matrix.python-version}},${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: 1
     strategy:
       matrix:
         go: [1.11, 1.14]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,6 +40,8 @@ jobs:
   go-lint:
     name: Go Lint
     runs-on: ubuntu-latest
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - uses: actions/setup-go@v1
         with:

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -48,6 +48,8 @@ jobs:
         go-version: [1.14]
         suite: ["network-forming", "commissioning", "connectivity", "network-latency"]
     runs-on: ubuntu-latest
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - uses: actions/setup-go@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,7 @@ jobs:
         os: [ubuntu-latest, macos-10.15]
     env:
       VIRTUAL_TIME_UART: 1
+      HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - uses: actions/setup-go@v1
         with:
@@ -69,6 +70,7 @@ jobs:
         VIRTUAL_TIME_UART: [0, 1]
     env:
       VIRTUAL_TIME_UART: ${{ matrix.VIRTUAL_TIME_UART }}
+      HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - uses: actions/setup-go@v1
         with:
@@ -92,6 +94,7 @@ jobs:
         VIRTUAL_TIME_UART: [0, 1]
     env:
       VIRTUAL_TIME_UART: ${{ matrix.VIRTUAL_TIME_UART }}
+      HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - uses: actions/setup-go@v1
         with:
@@ -105,6 +108,8 @@ jobs:
   signals:
     name: Signals (Py${{ matrix.python-version }}, ${{ matrix.os }}, VIRTUAL_TIME_UART=${{ matrix.VIRTUAL_TIME_UART }})
     runs-on: ${{ matrix.os }}
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: 1
     strategy:
       matrix:
         python-version: [3.6]


### PR DESCRIPTION
This PR resolves warnings in github actions by disabling homebrew auto update.