### PR TITLE
[dispatcher] collect COAP events

### DIFF
--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -29,7 +29,7 @@ name: Stress
 on: [push, pull_request]
 
 env:
-  OT_COMMIT: "a740350c5c4b3acd8b16bc04f14f2b95669db411" # Oct 19, 2020
+  OT_COMMIT: "2dc8d711c727007e30cfc9b0a0f88bd5d2f0a2a8" # Oct 19, 2020
   MAX_NETWORK_SIZE: 999
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ name: Test
 on: [push, pull_request]
 
 env:
-  OT_COMMIT: "a740350c5c4b3acd8b16bc04f14f2b95669db411" # Oct 19, 2020
+  OT_COMMIT: "2dc8d711c727007e30cfc9b0a0f88bd5d2f0a2a8" # Oct 19, 2020
   MAX_NETWORK_SIZE: 999
 
 jobs:

--- a/cli/README.md
+++ b/cli/README.md
@@ -8,6 +8,7 @@ Python libraries use the CLI to manage simulations.
 ## OTNS command list
 
 * [add](#add-type-x-x-y-y-rr-radio-range-id-node-id-restore)
+* [coaps](#coaps-enable)
 * [counters](#counters)
 * [cv](#cv-option-onoff-)
 * [del](#del-node-id-node-id-)
@@ -55,6 +56,26 @@ Done
 Done
 > add fed x 200 y 200 id 25
 25
+Done
+```
+
+### coaps enable
+
+Enable collecting info of CoAP messages.
+
+```
+> coaps enable
+Done
+```
+
+### coaps
+
+Show info of collected CoAP messages in yaml format.
+
+```
+> coaps
+- {time: 57019000, src: 2, id: 25421, type: 0, code: 2, uri: a/as, dst_addr: 'fdde:ad00:beef:0:0:ff:fe00:f000', dst_port: 61631, receivers: [{time: 57019961, dst: 1, src_addr: 'fdde:ad00:beef:0:0:ff:fe00:f001', src_port: 61631}]}
+- {time: 57019961, src: 1, id: 25421, type: 2, code: 68, dst_addr: 'fdde:ad00:beef:0:0:ff:fe00:f001', dst_port: 61631, receivers: [{time: 57021242, dst: 2, src_addr: 'fdde:ad00:beef:0:0:ff:fe00:f000', src_port: 61631}]}
 Done
 ```
 

--- a/cli/ast.go
+++ b/cli/ast.go
@@ -37,6 +37,7 @@ import (
 //noinspection GoStructTag
 type Command struct {
 	Add                 *AddCmd                 `  @@` //nolint
+	Coaps               *CoapsCmd               `| @@` //nolint
 	ConfigVisualization *ConfigVisualizationCmd `| @@` //nolint
 	CountDown           *CountDownCmd           `| @@` //nolint
 	Counters            *CountersCmd            `| @@` //nolint
@@ -288,6 +289,16 @@ type NodeType struct {
 //noinspection GoStructTag
 type AddNodeId struct {
 	Val int `"id" @Int` //nolint
+}
+
+//noinspection GoStructTag
+type CoapsCmd struct {
+	Cmd    struct{}    `"coaps"` //nolint
+	Enable *EnableFlag `@@ ?`    //nolint
+}
+
+type EnableFlag struct {
+	Dummy struct{} `"enable"` //nolint
 }
 
 //noinspection GoStructTag

--- a/dispatcher/coaps.go
+++ b/dispatcher/coaps.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2020, The OTNS Authors.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the
+//    names of its contributors may be used to endorse or promote products
+//    derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package dispatcher
+
+import (
+	. "github.com/openthread/ot-ns/types"
+	"github.com/simonlingoogle/go-simplelogger"
+)
+
+type CoapType int
+
+const (
+	CoapTypeConfirmable    CoapType = 0
+	CoapTypeNonConfirmable CoapType = 1
+	CoapTypeAcknowledgment CoapType = 2
+	CoapTypeReset          CoapType = 3
+)
+
+type CoapCode int
+
+type CoapMessageRecvInfo struct {
+	Timestamp uint64 `yaml:"time"`
+	DstNode   NodeId `yaml:"dst"`
+	SrcAddr   string `yaml:"src_addr"`
+	SrcPort   int    `yaml:"src_port"`
+}
+
+type CoapMessage struct {
+	Timestamp uint64                `yaml:"time"`
+	SrcNode   NodeId                `yaml:"src"`
+	ID        int                   `yaml:"id"`
+	Type      CoapType              `yaml:"type"`
+	Code      CoapCode              `yaml:"code"`
+	URI       string                `yaml:"uri,omitempty"`
+	DstAddr   string                `yaml:"dst_addr"`
+	DstPort   int                   `yaml:"dst_port"`
+	Error     string                `yaml:"error,omitempty"`
+	Receivers []CoapMessageRecvInfo `yaml:"receivers,flow"`
+}
+
+type coapsHandler struct {
+	messages []*CoapMessage
+}
+
+func (coaps *coapsHandler) OnSend(curTime uint64, nodeId NodeId, messageId int, coapType CoapType, coapCode CoapCode, uri string, peerAddr string, peerPort int) {
+	coaps.messages = append(coaps.messages, &CoapMessage{
+		Timestamp: curTime,
+		SrcNode:   nodeId,
+		ID:        messageId,
+		Type:      coapType,
+		Code:      coapCode,
+		URI:       uri,
+		DstAddr:   peerAddr,
+		DstPort:   peerPort,
+	})
+}
+
+func (coaps *coapsHandler) OnRecv(curTime uint64, nodeId NodeId, messageId int, coapType CoapType, coapCode CoapCode, uri string, peerAddr string, peerPort int) {
+	msg := coaps.findMessage(messageId, coapType, coapCode, uri)
+	if msg == nil {
+		simplelogger.Warnf("CoAP message %d,%d,%d,%s not sent but received by Node %d", messageId, coapType, coapCode, uri, nodeId)
+		return
+	}
+
+	msg.Receivers = append(msg.Receivers, CoapMessageRecvInfo{
+		Timestamp: curTime,
+		DstNode:   nodeId,
+		SrcAddr:   peerAddr,
+		SrcPort:   peerPort,
+	})
+}
+
+func (coaps *coapsHandler) OnSendError(nodeId NodeId, messageId int, coapType CoapType, coapCode CoapCode, uri string, peerAddr string, peerPort int, error string) {
+	msg := coaps.findMessage(messageId, coapType, coapCode, uri)
+	if msg == nil {
+		simplelogger.Warnf("CoAP message %d,%d,%d,%s not sent but received by Node %d", messageId, coapType, coapCode, uri, nodeId)
+		return
+	}
+
+	msg.Error = error
+}
+
+func (coaps *coapsHandler) findMessage(id int, coapType CoapType, coapCode CoapCode, uri string) *CoapMessage {
+	for i := len(coaps.messages) - 1; i >= 0; i-- {
+		msg := coaps.messages[i]
+		if msg.ID == id && msg.Type == coapType && msg.Code == coapCode && msg.URI == uri {
+			return msg
+		}
+	}
+
+	return nil
+}
+
+func (coaps *coapsHandler) DumpMessages() (ret []*CoapMessage) {
+	ret, coaps.messages = coaps.messages, nil
+	return
+}
+
+func newCoapsHandler() *coapsHandler {
+	coaps := &coapsHandler{
+		messages: nil,
+	}
+	return coaps
+}

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,6 @@ require (
 	google.golang.org/grpc v1.29.1
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c
 	honnef.co/go/tools v0.0.1-2020.1.4 // indirect
 )

--- a/pylibs/otns/cli/OTNS.py
+++ b/pylibs/otns/cli/OTNS.py
@@ -33,6 +33,8 @@ import signal
 import subprocess
 from typing import List, Union, Optional, Tuple, Dict, Any, Collection
 
+import yaml
+
 from .errors import OTNSCliError, OTNSExitedError
 
 
@@ -155,7 +157,7 @@ class OTNS(object):
             if line == b'':
                 self._on_otns_eof()
 
-            line = line.strip().decode('utf-8')
+            line = line.rstrip(b'\r\n').decode('utf-8')
             logging.info(f"OTNS >>> {line}")
             if line == 'Done':
                 return output
@@ -722,6 +724,17 @@ class OTNS(object):
         :param val: the Router downgrade threshold
         """
         self.node_cmd(nodeid, f'routerdowngradethreshold {val}')
+
+    def coaps_enable(self) -> None:
+        self._do_command('coaps enable')
+
+    def coaps(self) -> List[Dict]:
+        """
+        Get recent CoAP messages.
+        """
+        lines = self._do_command('coaps')
+        messages = yaml.safe_load('\n'.join(lines))
+        return messages
 
     @staticmethod
     def _expect_int(output: List[str]) -> int:

--- a/pylibs/setup.py
+++ b/pylibs/setup.py
@@ -40,4 +40,5 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.6',
+    install_requires=['PyYAML'],
 )

--- a/pylibs/unittests/test_basic.py
+++ b/pylibs/unittests/test_basic.py
@@ -26,7 +26,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 import logging
-import os
 import unittest
 from typing import Dict
 
@@ -98,7 +97,7 @@ class BasicTests(OTNSTestCase):
         self.go(3)
         self.assertEqual(ns.get_state(1), "leader")
 
-        for type in ("router", "fed","med", "sed"):
+        for type in ("router", "fed", "med", "sed"):
             nodeid = ns.add(type)
             self.go(10)
             self.assertFormPartitions(1)
@@ -293,6 +292,24 @@ class BasicTests(OTNSTestCase):
         for val in range(0, 33):
             ns.set_router_downgrade_threshold(nid, val)
             self.assertEqual(val, ns.get_router_downgrade_threshold(nid))
+
+    def testCoaps(self):
+        ns: OTNS = self.ns
+        ns.coaps_enable()
+        for i in range(10):
+            id = ns.add('router')
+            ns.node_cmd(id, 'routerselectionjitter 1')
+            ns.go(5)
+
+        ns.go(10)
+        msgs = ns.coaps()
+        routers = {}
+        for msg in msgs:
+            if msg.get('uri') == 'a/as':
+                routers[msg['src']] = msg['id']
+
+        # Node 2 ~ 10 should become Routers by sending `a/as`
+        self.assertEqual(set(routers), set(range(2, 11)))
 
 
 if __name__ == '__main__':

--- a/script/install
+++ b/script/install
@@ -39,7 +39,7 @@ install_otns()
 install_pyotns()
 {
     cd pylibs
-    python3 setup.py install --user --prefix=
+    python3 setup.py install --user --prefix= 2>/dev/null
     cd -
 }
 


### PR DESCRIPTION
This PR collects COAP events emitted by OT and provide interfaces for collecting COAP information. 

**This feature can be useful to analyze network performance metrics using COAP messages.**

**Depends on https://github.com/openthread/openthread/pull/5656**

- Process COAP events emitted by OT
- OT CLI: add `coaps` command 
  - Enable this feature (disabled by default): `coaps enable`
  - Get and purge collected COAP message infos: `coaps` 
- `pyOTNS` add corresponding methods. 

```
> coaps enable
Done
> coaps
- {time: 57019000, src: 2, id: 25421, type: 0, code: 2, uri: a/as, dst_addr: 'fdde:ad00:beef:0:0:ff:fe00:f000', dst_port: 61631, receivers: [{time: 57019961, dst: 1, src_addr: 'fdde:ad00:beef:0:0:ff:fe00:f001', src_port: 61631}]}
- {time: 57019961, src: 1, id: 25421, type: 2, code: 68, dst_addr: 'fdde:ad00:beef:0:0:ff:fe00:f001', dst_port: 61631, receivers: [{time: 57021242, dst: 2, src_addr: 'fdde:ad00:beef:0:0:ff:fe00:f000', src_port: 61631}]}
Done
```