### PR TITLE
[openthread] use latest OT commit

### DIFF
--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -29,7 +29,8 @@ name: Stress
 on: [push, pull_request]
 
 env:
-  OT_COMMIT: "e48a1ff9807f66d448a9e76ad64038dc6c67adce" # Oct 17, 2020
+  OT_COMMIT: "a740350c5c4b3acd8b16bc04f14f2b95669db411" # Oct 19, 2020
+  MAX_NETWORK_SIZE: 999
 
 jobs:
   cancel-previous-runs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,8 @@ name: Test
 on: [push, pull_request]
 
 env:
-  OT_COMMIT: "e48a1ff9807f66d448a9e76ad64038dc6c67adce" # Oct 17, 2020
+  OT_COMMIT: "a740350c5c4b3acd8b16bc04f14f2b95669db411" # Oct 19, 2020
+  MAX_NETWORK_SIZE: 999
 
 jobs:
   cancel-previous-runs:


### PR DESCRIPTION
To fix the `./script/bootstrap` error.

Depends on https://github.com/openthread/openthread/pull/5668