### PR TITLE
[go] support go 1.13+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ on: [push, pull_request]
 
 jobs:
   cancel-previous-runs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@master
         env:
@@ -43,15 +43,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - go: 1.11
-            os: ubuntu-latest
-          - go: 1.12
-            os: ubuntu-latest
           - go: 1.13
-            os: ubuntu-latest
+            os: ubuntu-20.04
           - go: 1.14
-            os: ubuntu-latest
-          - go: 1.11
+            os: ubuntu-20.04
+          - go: 1.15
+            os: ubuntu-20.04
+          - go: 1.13
             os: macos-10.15
     steps:
       - uses: actions/setup-go@v1

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -30,7 +30,7 @@ on: [push, pull_request]
 
 jobs:
   cancel-previous-runs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@master
         env:
@@ -44,9 +44,9 @@ jobs:
       HOMEBREW_NO_AUTO_UPDATE: 1
     strategy:
       matrix:
-        go: [1.11, 1.14]
+        go: [1.13, 1.15]
         python-version: [3.6, 3.8]
-        os: [ubuntu-latest, macos-10.15]
+        os: [ubuntu-20.04, macos-10.15]
     steps:
       - uses: actions/setup-go@v1
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ on: [push, pull_request]
 
 jobs:
   cancel-previous-runs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@master
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ on: [push, pull_request]
 
 jobs:
   cancel-previous-runs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@master
         env:
@@ -39,7 +39,7 @@ jobs:
 
   go-lint:
     name: Go Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -33,7 +33,7 @@ env:
 
 jobs:
   cancel-previous-runs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@master
         env:
@@ -47,7 +47,7 @@ jobs:
         python-version: [3.8]
         go-version: [1.14]
         suite: ["network-forming", "commissioning", "connectivity", "network-latency", "multicast-performance", "otns-performance"]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ env:
 
 jobs:
   cancel-previous-runs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@master
         env:
@@ -45,14 +45,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-10.15]
+        os: [ubuntu-20.04, macos-10.15]
     env:
       VIRTUAL_TIME_UART: 1
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.11
+          go-version: 1.13
       - uses: actions/checkout@v2
       - name: Test
         run: |
@@ -66,7 +66,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6]
-        os: [ubuntu-latest, macos-10.15]
+        os: [ubuntu-20.04, macos-10.15]
         VIRTUAL_TIME_UART: [0, 1]
     env:
       VIRTUAL_TIME_UART: ${{ matrix.VIRTUAL_TIME_UART }}
@@ -74,7 +74,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.11
+          go-version: 1.13
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
@@ -90,7 +90,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6]
-        os: [ubuntu-latest, macos-10.15]
+        os: [ubuntu-20.04, macos-10.15]
         VIRTUAL_TIME_UART: [0, 1]
     env:
       VIRTUAL_TIME_UART: ${{ matrix.VIRTUAL_TIME_UART }}
@@ -98,7 +98,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.11
+          go-version: 1.13
       - uses: actions/checkout@v2
       - name: Run Examples
         run: |
@@ -113,12 +113,12 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6]
-        os: [ubuntu-latest, macos-10.15]
+        os: [ubuntu-20.04, macos-10.15]
         VIRTUAL_TIME_UART: [0, 1]
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.11
+          go-version: 1.13
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -2,7 +2,7 @@
 
 ## Install Go
 
-OTNS requires [Go 1.11+](https://golang.org/dl/) to build:
+OTNS requires [Go 1.13+](https://golang.org/dl/) to build:
 
  - Install Go from https://golang.org/dl/
  - Add `$(go env GOPATH)/bin` (normally `$HOME/go/bin`) to `$PATH`.


### PR DESCRIPTION
OTNS used to support Go 1.11+.

This commit changed OTNS to only support Go 1.13+.

Go 1.13 was released in 2019/09/03, so it has been quite a long time.