### PR TITLE
[github-actions] fix checks

### DIFF
--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -28,9 +28,6 @@ name: Stress
 
 on: [push, pull_request]
 
-env:
-  MAX_NETWORK_SIZE: 999
-
 jobs:
   cancel-previous-runs:
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,6 @@ name: Test
 
 on: [push, pull_request]
 
-env:
-  MAX_NETWORK_SIZE: 999
-
 jobs:
   cancel-previous-runs:
     runs-on: ubuntu-20.04
@@ -102,19 +99,19 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run Examples
         run: |
-          export VIRTUAL_TIME_UART=${{ matrix.VIRTUAL_TIME_UART }}
           ./script/test py-examples
 
   signals:
     name: Signals (Py${{ matrix.python-version }}, ${{ matrix.os }}, VIRTUAL_TIME_UART=${{ matrix.VIRTUAL_TIME_UART }})
     runs-on: ${{ matrix.os }}
-    env:
-      HOMEBREW_NO_AUTO_UPDATE: 1
     strategy:
       matrix:
         python-version: [3.6]
         os: [ubuntu-20.04, macos-10.15]
         VIRTUAL_TIME_UART: [0, 1]
+    env:
+      VIRTUAL_TIME_UART: ${{ matrix.VIRTUAL_TIME_UART }}
+      HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - uses: actions/setup-go@v1
         with:

--- a/script/test
+++ b/script/test
@@ -31,7 +31,7 @@
 set -euox pipefail
 
 OT_DIR=${OT_DIR:-$HOME/src/openthread}
-OTBIN_DIR=$OT_DIR/output/simulation/bin
+OTBIN_DIR=$OT_DIR/build/simulation/examples/apps/cli
 
 installed()
 {
@@ -74,7 +74,7 @@ get_openthread()
     if ! [[ -x $OT_DIR ]]; then
         mkdir -p "$OT_DIR"
         (
-            OT_COMMIT=${OT_COMMIT:-master}
+            OT_COMMIT=${OT_COMMIT:-main}
 
             cd "$OT_DIR"
             git init
@@ -82,8 +82,7 @@ get_openthread()
             git fetch origin "${OT_COMMIT}" --depth 1
             git reset --hard FETCH_HEAD
 
-            repeat 3 ./script/bootstrap
-            ./bootstrap
+            repeat 3 ./script/bootstrap >/dev/null 2>&1
         )
     fi
 }
@@ -92,7 +91,7 @@ build_openthread()
 {
     get_openthread
     cd "$OT_DIR"
-    make -f "$OT_DIR"/examples/Makefile-simulation OTNS=1
+    script/cmake-build simulation -DOT_OTNS=ON -DOT_SIMULATION_VIRTUAL_TIME=ON -DOT_SIMULATION_VIRTUAL_TIME_UART="${VIRTUAL_TIME_UART:-OFF}" -DOT_SIMULATION_MAX_NETWORK_SIZE=999
     cd -
 }
 
@@ -118,6 +117,7 @@ check_py_example()
     sleep 10
     killall otns || true
     wait $pid || die "Run pyOTNS example failed :$1"
+    sleep 3
 }
 
 py_examples()

--- a/visualize/grpc/pb/visualize_grpc.proto
+++ b/visualize/grpc/pb/visualize_grpc.proto
@@ -28,6 +28,8 @@ syntax = "proto3";
 
 package visualize_grpc_pb;
 
+option go_package = "github.com/openthread/ot-ns/visualize/grpc/pb";
+
 message VisualizeRequest {
 
 }


### PR DESCRIPTION
This commit contains necessary changes to make GitHub Actions work again:
- Switch openthread branch from `master` to `main`.
- Switch openthread building from `Makefile` to `cmake`: `script/cmake-build simulation -DOT_OTNS=ON ...`