### PR TITLE
[scripts] fix openthread build

### DIFF
--- a/script/test
+++ b/script/test
@@ -31,7 +31,7 @@
 set -euox pipefail
 
 OT_DIR=${OT_DIR:-$HOME/src/openthread}
-OTBIN_DIR=$OT_DIR/build/simulation/examples/apps/cli
+OTBIN_DIR=$OT_DIR/build/otns/examples/apps/cli
 
 installed()
 {
@@ -90,9 +90,13 @@ get_openthread()
 build_openthread()
 {
     get_openthread
-    cd "$OT_DIR"
-    script/cmake-build simulation -DOT_OTNS=ON -DOT_SIMULATION_VIRTUAL_TIME=ON -DOT_SIMULATION_VIRTUAL_TIME_UART="${VIRTUAL_TIME_UART:-OFF}" -DOT_SIMULATION_MAX_NETWORK_SIZE=999
-    cd -
+    (
+        cd "$OT_DIR"
+        mkdir -p build/otns
+        cd build/otns
+        cmake -GNinja ../.. -DOT_PLATFORM=simulation -DOT_OTNS=ON -DOT_SIMULATION_VIRTUAL_TIME=ON -DOT_SIMULATION_VIRTUAL_TIME_UART="${VIRTUAL_TIME_UART:-OFF}" -DOT_SIMULATION_MAX_NETWORK_SIZE=999
+        ninja
+    )
 }
 
 py_unittests()
@@ -117,7 +121,6 @@ check_py_example()
     sleep 10
     killall otns || true
     wait $pid || die "Run pyOTNS example failed :$1"
-    sleep 3
 }
 
 py_examples()

--- a/script/test
+++ b/script/test
@@ -94,6 +94,16 @@ build_openthread()
         cd "$OT_DIR"
         mkdir -p build/otns
         cd build/otns
+
+        options=(
+            -DOT_PLATFORM=simulation
+            -DOT_OTNS=ON
+            -DOT_SIMULATION_VIRTUAL_TIME=ON
+            -DOT_SIMULATION_VIRTUAL_TIME_UART="${VIRTUAL_TIME_UART:-OFF}"
+            -DOT_SIMULATION_MAX_NETWORK_SIZE=999
+            -DOT_COMMISSIONER=ON
+            -DOT_JOINER=ON
+        )
         cmake -GNinja ../.. -DOT_PLATFORM=simulation -DOT_OTNS=ON -DOT_SIMULATION_VIRTUAL_TIME=ON -DOT_SIMULATION_VIRTUAL_TIME_UART="${VIRTUAL_TIME_UART:-OFF}" -DOT_SIMULATION_MAX_NETWORK_SIZE=999
         ninja
     )

--- a/script/test
+++ b/script/test
@@ -95,16 +95,16 @@ build_openthread()
         mkdir -p build/otns
         cd build/otns
 
-        options=(
-            -DOT_PLATFORM=simulation
-            -DOT_OTNS=ON
-            -DOT_SIMULATION_VIRTUAL_TIME=ON
-            -DOT_SIMULATION_VIRTUAL_TIME_UART="${VIRTUAL_TIME_UART:-OFF}"
-            -DOT_SIMULATION_MAX_NETWORK_SIZE=999
-            -DOT_COMMISSIONER=ON
-            -DOT_JOINER=ON
+        local options=(
+            "-DOT_PLATFORM=simulation"
+            "-DOT_OTNS=ON"
+            "-DOT_SIMULATION_VIRTUAL_TIME=ON"
+            "-DOT_SIMULATION_VIRTUAL_TIME_UART=${VIRTUAL_TIME_UART:-OFF}"
+            "-DOT_SIMULATION_MAX_NETWORK_SIZE=999"
+            "-DOT_COMMISSIONER=ON"
+            "-DOT_JOINER=ON"
         )
-        cmake -GNinja ../.. -DOT_PLATFORM=simulation -DOT_OTNS=ON -DOT_SIMULATION_VIRTUAL_TIME=ON -DOT_SIMULATION_VIRTUAL_TIME_UART="${VIRTUAL_TIME_UART:-OFF}" -DOT_SIMULATION_MAX_NETWORK_SIZE=999
+        cmake -GNinja ../.. "${options[@]}"
         ninja
     )
 }


### PR DESCRIPTION
This commit fix openthread build that may cause test failures because cmake-build uses `OT_COVERAGE=ON`.