### PR TITLE
[tests] set `OT_COVERAGE=ON` if `COVERAGE=1`

### DIFF
--- a/script/test
+++ b/script/test
@@ -104,6 +104,14 @@ build_openthread()
             "-DOT_COMMISSIONER=ON"
             "-DOT_JOINER=ON"
         )
+
+        local COVERAGE=${COVERAGE:-0}
+        if [[ $COVERAGE == 1 ]]; then
+            options+=(
+                "-DOT_COVERAGE=ON"
+            )
+        fi
+
         cmake -GNinja ../.. "${options[@]}"
         ninja
     )


### PR DESCRIPTION
to fix github action failures (e.g. https://github.com/openthread/openthread/pull/6515/checks?check_run_id=2445158652)

Fixes https://github.com/openthread/openthread/issues/6520