### PR TITLE
[build] respect the THREAD_VERSION environment variable

### DIFF
--- a/script/test
+++ b/script/test
@@ -103,6 +103,7 @@ build_openthread()
             "-DOT_SIMULATION_MAX_NETWORK_SIZE=999"
             "-DOT_COMMISSIONER=ON"
             "-DOT_JOINER=ON"
+            "-DOT_THREAD_VERSION=${THREAD_VERSION:-1.2}"
         )
 
         local COVERAGE=${COVERAGE:-0}


### PR DESCRIPTION
I've noticed on the [CI logs](https://github.com/openthread/openthread/runs/2483259697#step:6:472), that step `cli-ftd-otns` inside `Simulation 1.1` suite in OpenThread, builds in fact Thread 1.2 version. This PR ensures that `THREAD_VERSION` env is respected.