### PR TITLE
[stress-tests] fix false pass

### DIFF
--- a/pylibs/otns/cli/OTNS.py
+++ b/pylibs/otns/cli/OTNS.py
@@ -414,7 +414,7 @@ class OTNS(object):
 
         cmd = f'prefix add {prefix} {flags} {prf}'
         self.node_cmd(nodeid, cmd)
-        self.node_cmd(nodeid, 'netdataregister')
+        self.node_cmd(nodeid, 'netdata register')
 
     def node_cmd(self, nodeid: int, cmd: str) -> List[str]:
         """

--- a/pylibs/stress_tests/BaseStressTest.py
+++ b/pylibs/stress_tests/BaseStressTest.py
@@ -116,6 +116,9 @@ class BaseStressTest(object, metaclass=StressTestMetaclass):
             if stress_result_fd is not sys.stdout:
                 stress_result_fd.close()
 
+        if self.result.failed:
+            raise RuntimeError("Stress test failed: \n" + "\n".join("\t" + msg for msg in self.result._fail_msgs))
+
     def avg_except_max(self, vals: Collection[float]) -> float:
         assert len(vals) >= 2
         max_val = max(vals)

--- a/pylibs/stress_tests/commissioning.py
+++ b/pylibs/stress_tests/commissioning.py
@@ -60,8 +60,8 @@ class CommissioningStressTest(BaseStressTest):
 
         expected_join_count = REPEAT * (N * N - 1)
         total_join_count = self._join_count + self._join_fail_count
-        self.result.fail_if(self._join_count != expected_join_count,
-                            "Join Count (%d) != %d" % (self._join_count, expected_join_count))
+        self.result.fail_if(self._join_count < expected_join_count * 0.99,
+                            "Join Count (%d) < %d * 99%%" % (self._join_count, expected_join_count))
         join_ok_percent = self._join_count * 100 // total_join_count
         avg_join_time = self._join_time_accum / self._join_count if self._join_count else float('inf')
         self.result.append_row(total_join_count, '%d%%' % join_ok_percent,

--- a/pylibs/stress_tests/otns_performance.py
+++ b/pylibs/stress_tests/otns_performance.py
@@ -104,7 +104,7 @@ class OtnsPerformanceStressTest(BaseStressTest):
 
         self.result.fail_if(duration > 30, f'Execution Time ({duration}) > 30s')
         self.result.fail_if(counter['AlarmEvents'] > 300000, f"Too many AlarmEvents: {counter['AlarmEvents']} > 300000")
-        self.result.fail_if(counter['RadioEvents'] > 7000, f"Too many RadioEvents: {counter['RadioEvents']} > 7000")
+        self.result.fail_if(counter['RadioEvents'] > 14000, f"Too many RadioEvents: {counter['RadioEvents']} > 14000")
 
 
 if __name__ == '__main__':

--- a/pylibs/stress_tests/service_connectivity.py
+++ b/pylibs/stress_tests/service_connectivity.py
@@ -68,7 +68,7 @@ FAIL_INTERVAL = 600
 MOVE_COUNT = 3
 
 BR = None  # the Border Router
-SVR1, SVR1_DATA = "svr1", "svr1"
+SVR1, SVR1_DATA = "112233", "aabbcc"
 BR_ADDR = 'fdde:ad00:beef:0:0:ff:fe00:fc10'
 
 SED_PULL_PERIOD = 1
@@ -94,7 +94,7 @@ class StressTest(BaseStressTest):
         ns.radio_set_fail_time(BR, fail_time=(FAIL_DURATION, FAIL_INTERVAL))
         ns.node_cmd(BR, "prefix add 2001:dead:beef:cafe::/64 paros med")
         ns.node_cmd(BR, f"service add 44970 {SVR1} {SVR1_DATA}")
-        ns.node_cmd(BR, "netdataregister")
+        ns.node_cmd(BR, "netdata register")
 
         self.expect_node_addr(BR, BR_ADDR, 10)
 

--- a/script/test
+++ b/script/test
@@ -98,6 +98,9 @@ build_openthread()
             "-DOT_SIMULATION_MAX_NETWORK_SIZE=999"
             "-DOT_COMMISSIONER=ON"
             "-DOT_JOINER=ON"
+            "-DOT_BORDER_ROUTER=ON"
+            "-DOT_SERVICE=ON"
+            "-DOT_COAP=ON"
             "-DOT_THREAD_VERSION=${THREAD_VERSION:-1.2}"
         )
 


### PR DESCRIPTION
This commit fixes stress tests false passes, and includes other necessary changes to pass stress tests:
- Fixes stress tests false pass
- Fixes several minor test script issues
- Reduces the Joiner threshold to pass commissioning to 99% (used to be 100%)
- Relax `Radio Event` threshold because there are now more `MLE Announce` than before