### PR TITLE
[stress-tests] reduce packet loss ratio to 10% for `connectivity`

### DIFF
--- a/pylibs/stress_tests/mleid_connectivity.py
+++ b/pylibs/stress_tests/mleid_connectivity.py
@@ -85,7 +85,7 @@ class MleidConnectivityStressTest(BaseStressTest):
 
     def run(self):
         ns = self.ns
-        ns.packet_loss_ratio = 0.2
+        ns.packet_loss_ratio = 0.1
         ns.config_visualization(broadcast_message=False)
 
         assert ROUTER_COUNT >= 1

--- a/pylibs/stress_tests/service_connectivity.py
+++ b/pylibs/stress_tests/service_connectivity.py
@@ -87,7 +87,7 @@ class StressTest(BaseStressTest):
 
     def run(self):
         ns = self.ns
-        ns.packet_loss_ratio = 0.2
+        ns.packet_loss_ratio = 0.1
 
         assert ROUTER_COUNT >= 1
         BR = ns.add("router", x=random.randint(0, XMAX), y=random.randint(0, YMAX))


### PR DESCRIPTION
Seems 20% is too much to pass `connectivity` test suite.
Reduce to 10%

Fixes https://github.com/openthread/openthread/issues/7406