### PR TITLE
[scripts] support build openthread using `script/test`

### DIFF
--- a/script/common.sh
+++ b/script/common.sh
@@ -25,18 +25,20 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-set -e
-
-# shellcheck source=script/utils.sh
-. "$(dirname "$0")"/utils.sh
+set -euox pipefail
 
 if [[ "$(uname)" == "Darwin" ]]; then
     export readonly Darwin=1
+    export readonly Linux=0
 elif [[ "$(uname)" == "Linux" ]]; then
+    export readonly Darwin=0
     export readonly Linux=1
 else
     die "Unknown OS: $(uname)"
 fi
+
+# shellcheck source=script/utils.sh
+. "$(dirname "$0")"/utils.sh
 
 export readonly SCRIPTDIR
 SCRIPTDIR=$(realpath "$(dirname "$0")")

--- a/script/install-deps
+++ b/script/install-deps
@@ -30,8 +30,6 @@
 # shellcheck source=script/common.sh
 . "$(dirname "$0")"/common.sh
 
-set -e
-
 apt_update_once=0
 
 install_packages()

--- a/script/setup-dev
+++ b/script/setup-dev
@@ -140,4 +140,5 @@ install_nodejs
 install_go_bindata
 install_py_libraries
 install_pretty_tools
+install_openthread_buildtools
 go mod tidy

--- a/script/test
+++ b/script/test
@@ -28,8 +28,6 @@
 # shellcheck source=script/common.sh
 . "$(dirname "$0")"/common.sh
 
-set -euox pipefail
-
 OT_DIR=${OT_DIR:-}
 OTBIN_DIR=
 
@@ -73,10 +71,6 @@ get_openthread()
     if [[ -z $OT_DIR ]]; then
         OT_DIR=$PWD/openthread
         git submodule update --init
-        (
-            cd "$OT_DIR"
-            repeat 3 ./script/bootstrap >/dev/null 2>&1
-        )
     fi
 
     OTBIN_DIR=$OT_DIR/build/otns/examples/apps/cli
@@ -85,6 +79,9 @@ get_openthread()
 build_openthread()
 {
     get_openthread
+
+    install_openthread_buildtools
+
     (
         cd "$OT_DIR"
         mkdir -p build/otns
@@ -195,6 +192,10 @@ main()
             stress-tests)
                 stress_tests "$2"
                 shift 2
+                ;;
+            build-openthread)
+                build_openthread
+                shift 1
                 ;;
             *)
                 echo "Error: Unsupported test $1" >&2

--- a/script/utils.sh
+++ b/script/utils.sh
@@ -113,6 +113,10 @@ function install_pretty_tools()
 
 install_openthread_buildtools()
 {
+    if installed "ninja"; then
+        return 0
+    fi
+
     if [[ $Darwin == 1 ]]; then
         brew install ninja
     else

--- a/script/utils.sh
+++ b/script/utils.sh
@@ -25,6 +25,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+readonly Darwin
+
 function die()
 {
     echo "fatal: $1"
@@ -107,4 +109,13 @@ function install_pretty_tools()
 
     install_package shfmt --brew shfmt
     install_package shellcheck --apt shellcheck --brew shellcheck
+}
+
+install_openthread_buildtools()
+{
+    if [[ $Darwin == 1 ]]; then
+        brew install ninja
+    else
+        sudo apt-get install ninja-build
+    fi
 }


### PR DESCRIPTION
This commit allows building OpenThread executables that works with OTNS by executing `script/test build-openthread`.