### PR TITLE
[test] increase wait time for leader start

### DIFF
--- a/pylibs/stress_tests/commissioning.py
+++ b/pylibs/stress_tests/commissioning.py
@@ -98,7 +98,7 @@ class CommissioningStressTest(BaseStressTest):
         ns.node_cmd(G[cr][cc], 'dataset commit active')
         ns.ifconfig_up(G[cr][cc])
         ns.thread_start(G[cr][cc])
-        ns.go(10)
+        ns.go(15)
         assert ns.get_state(G[cr][cc]) == 'leader'
         started[cr][cc] = joined[cr][cc] = True
 

--- a/pylibs/stress_tests/network_forming.py
+++ b/pylibs/stress_tests/network_forming.py
@@ -50,7 +50,7 @@ MAX_N = 6
 REPEAT = int(os.getenv('STRESS_LEVEL', '1')) * 3
 
 EXPECTED_MERGE_TIME_MAX = [
-    None, 3, 6, 12, 20, 50, 100
+    None, 10, 13, 19, 27, 57, 107
 ]
 
 

--- a/pylibs/stress_tests/otns_performance.py
+++ b/pylibs/stress_tests/otns_performance.py
@@ -70,7 +70,7 @@ class OtnsPerformanceStressTest(BaseStressTest):
                 ns.node_cmd(nid, 'routerdowngradethreshold 33')
                 expected_state = 'leader' if (r, c) == (0, 0) else 'router'
                 self.expect_node_state(nid, expected_state, 100)
-                ns.go(10)
+                ns.go(15)
 
         secs = 0
         formed_one_partition_ok = False

--- a/pylibs/unittests/test_basic.py
+++ b/pylibs/unittests/test_basic.py
@@ -57,7 +57,7 @@ class BasicTests(OTNSTestCase):
             logging.info("testOneNode round %d", i + 1)
             ns = self.ns
             ns.add("router")
-            ns.go(4)
+            ns.go(10)
             self.assertFormPartitions(1)
             self.tearDown()
             self.setUp()
@@ -65,7 +65,7 @@ class BasicTests(OTNSTestCase):
     def testAddNode(self):
         ns = self.ns
         ns.add("router")
-        self.go(4)
+        self.go(10)
         self.assertFormPartitions(1)
 
         ns.add("router")
@@ -94,7 +94,7 @@ class BasicTests(OTNSTestCase):
         ns = self.ns
         ns.add("router")
 
-        self.go(4)
+        self.go(10)
         self.assertEqual(ns.get_state(1), "leader")
 
         for type in ("router", "fed", "med", "sed"):
@@ -196,7 +196,7 @@ class BasicTests(OTNSTestCase):
     def testCliCmd(self):
         ns = self.ns
         id = ns.add("router")
-        self.go(4)
+        self.go(10)
         self.assertTrue(ns.get_state(id), 'leader')
 
     def testCounters(self):

--- a/pylibs/unittests/test_commissioning.py
+++ b/pylibs/unittests/test_commissioning.py
@@ -73,7 +73,7 @@ class BasicTests(OTNSTestCase):
         ns.node_cmd(n1, "dataset commit active")
         ns.ifconfig_up(n1)
         ns.thread_start(n1)
-        self.go(30)
+        self.go(35)
         self.assertTrue(ns.get_state(n1) == "leader")
         ns.commissioner_start(n1)
         ns.commissioner_joiner_add(n1, "*", "TEST123")


### PR DESCRIPTION
This commit increases the wait time for leader start. This is to
address the changes in behavior from Thread 1.3 spec related to the
number of MLE Parent Request messages that device needs to send in
the first attach attempt before it can become leader.  The new design
requires a device to send a total of six Parent Request messages,
first two to routers followed by four to routers and REEDs, each
having its own corresponding wait time.

----

_Background_:
This is in preparation of the upcoming PR in OT which will change the MLE 
attach behavior. 
