### PR TITLE
[dispatcher] receive radio state event of simulated node

### DIFF
--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -874,6 +874,8 @@ func (d *Dispatcher) handleStatusPush(srcid NodeId, data string) {
 		} else if sp[0] == "mode" {
 			mode := ParseNodeMode(sp[1])
 			d.vis.SetNodeMode(srcid, mode)
+		} else if sp[0] == "radio_state" {
+			// TODO: calculate energy consumption based on radio state changes of each node
 		} else {
 			simplelogger.Warnf("unknown status push: %s=%s", sp[0], sp[1])
 		}


### PR DESCRIPTION
Based on the PR [#7500](https://github.com/openthread/openthread/pull/7500), simulated devices will emit their radio state change as a sub event of "Push Status". This commit adds a condition to avoid unnecessary simplelogger's warns when it happens.