### PR TITLE
[stress-test] relax ping test to allow collision-avoidance delay

### DIFF
--- a/pylibs/stress_tests/ping_latency.py
+++ b/pylibs/stress_tests/ping_latency.py
@@ -34,7 +34,7 @@
 # Fault Injections:
 #   None
 # Pass Criteria:
-#   Max ping latency < 100ms
+#   Max ping latency < 300ms
 #
 import logging
 import math
@@ -152,7 +152,7 @@ class StressTest(BaseStressTest):
             row = ['%dB' % datasize]
             for n, s in latencys:
                 row.append('%dms' % (s / n) if n > 0 else 'NODATA')
-                self.result.fail_if(s / n > 100, "average ping latency > 100ms")
+                self.result.fail_if(s / n > 300, "average ping latency > 300ms")
 
             self.result.append_row(*row)
 


### PR DESCRIPTION
This commit relaxes the check in `ping_latency.py` stress test to 300
msec (from 100 msec). This is to accommodate the "collision avoidance
delay mechanism" which is intended to help prevent self-interference
This mechanism applies a delay after a successful frame tx to a
neighbor which is expected to forward the frame before any next frame
tx.

----

Related to: 
- https://github.com/openthread/openthread/pull/7512