### PR TITLE
[Fix build error] Attempt to fix golang build error

### DIFF
--- a/script/install-deps
+++ b/script/install-deps
@@ -52,6 +52,16 @@ install_grpcwebproxy()
     fi
 }
 
+install_golangci_lint()
+{
+    if [[ $Darwin == 1 ]]; then
+        brew install golangci-lint
+        brew upgrade golangci-lint
+    else
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.49.0
+    fi
+}
+
 install_python_libs()
 {
     python3 -m pip install --user setuptools
@@ -62,6 +72,7 @@ main()
     install_packages
     install_grpcwebproxy
     install_python_libs
+    install_golangci_lint
 }
 
 main

--- a/script/install-deps
+++ b/script/install-deps
@@ -55,7 +55,7 @@ install_grpcwebproxy()
 install_golangci_lint()
 {
     if [[ $Linux == 1 ]]; then
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.49.0
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)"/bin v1.49.0
     fi
 }
 

--- a/script/install-deps
+++ b/script/install-deps
@@ -54,10 +54,7 @@ install_grpcwebproxy()
 
 install_golangci_lint()
 {
-    if [[ $Darwin == 1 ]]; then
-        brew install golangci-lint
-        brew upgrade golangci-lint
-    else
+    if [[ $Linux == 1 ]]; then
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.49.0
     fi
 }


### PR DESCRIPTION
# Main contribution
This PR is an attempt to solve this current bug where all PRs are failing to build (with Golang 1.17 and 1.18).

I believe that It is failing because of an old golangci-lint version of is being used. exportloopref Is causing this error at:

golangci-lint run -E goimports -E whitespace -E goconst -E exportloopref -E unconvert --fix bindata.go
At this link https://golangci-lint.run/usage/install/ we can see how to fix it.