### PR TITLE
[pretty] fix installing shfmt

### DIFF
--- a/script/utils.sh
+++ b/script/utils.sh
@@ -107,7 +107,7 @@ function install_pretty_tools()
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)"/bin v1.47.2
     fi
 
-    install_package shfmt --brew shfmt
+    go install mvdan.cc/sh/v3/cmd/shfmt@latest
     install_package shellcheck --apt shellcheck --brew shellcheck
 }
 


### PR DESCRIPTION
This commit installs shfmt via `go install mvdan.cc/sh/v3/cmd/shfmt@latest`