### PR TITLE
[pylibs] improve unittest coverage

### DIFF
--- a/pylibs/unittests/test_basic.py
+++ b/pylibs/unittests/test_basic.py
@@ -913,6 +913,8 @@ class BasicTests(OTNSTestCase):
             ns.add('sed')
             ns.go(30)
             self.assertFormPartitions(1)
+            for nid in range(1, 8):
+                self.assertEqual('15', ns.node_cmd(nid, 'channel')[0])
 
     def testPhyStats(self):
         self.tearDown()

--- a/pylibs/unittests/test_commissioning.py
+++ b/pylibs/unittests/test_commissioning.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2020-2024, The OTNS Authors.
+# Copyright (c) 2020-2025, The OTNS Authors.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -101,6 +101,36 @@ class CommissioningTests(OTNSTestCase):
 
         ns.ifconfig_up(n2)
         ns.joiner_start(n2, "TEST123")
+        self.go(100)
+        ns.thread_start(n2)
+        self.go(100)
+        c = ns.counters()
+        print('counters', c)
+        joins = ns.joins()
+        print('joins', joins)
+        self.assertFormPartitions(1)
+        self.assertTrue(joins and joins[0][1] > 0)  # assert join success
+
+    def testCommissioningOneHopWithSteeringDataAndDomain(self):
+        ns = self.ns
+
+        n1 = ns.add("router")
+        n2 = ns.add("med")
+        joiner_eui = ns.node_cmd(2, "eui64")[0]
+
+        self.setFirstNodeDataset(n1)
+        # Set a non-default Thread Domain Name. This will be sent in the MLE Discovery Response.
+        ns.node_cmd(1, 'domainname TestingDomainThr')
+        ns.ifconfig_up(n1)
+        ns.thread_start(n1)
+        self.go(35)
+        self.assertTrue(ns.get_state(n1) == "leader")
+
+        ns.commissioner_start(n1)
+        ns.commissioner_joiner_add(n1, joiner_eui, "J01NM3")
+
+        ns.ifconfig_up(n2)
+        ns.joiner_start(n2, "J01NM3")
         self.go(100)
         ns.thread_start(n2)
         self.go(100)


### PR DESCRIPTION
Adds channel check for -ot-script parameter. Adds a commissioning test where a domain name and steering data are used.