### PR TITLE
[script] check for minimum Go/Python3 versions

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -31,6 +31,11 @@
 
 set -euxo pipefail
 
+OTNS_GO_VERSION_MIN=23
+OTNS_PYTHON3_VERSION_MIN=9
+GOLANG_APT_PKG="golang-go"
+GOLANG_BREW_PKG="golang"
+
 if [[ "$(uname)" == "Darwin" ]]; then
     declare -rx Darwin=1
     declare -rx Linux=0
@@ -44,6 +49,22 @@ fi
 
 # shellcheck source=script/utils.sh
 . "$(dirname "$0")"/utils.sh
+
+# Check if Go is installed and version is high enough. Auto-install if possible.
+if installed go; then
+    if ! check_minimum_go_version "${OTNS_GO_VERSION_MIN}"; then
+        die "Please install Go 1.${OTNS_GO_VERSION_MIN} or higher manually from https://go.dev/dl/ , and retry."
+    fi
+else
+    install_golang "${OTNS_GO_VERSION_MIN}" "${GOLANG_APT_PKG}" "${GOLANG_BREW_PKG}"
+fi
+
+# Check if Python is installed and version is high enough. Auto-install later on, if needed.
+if installed python3; then
+    if ! check_minimum_python3_version "${OTNS_PYTHON3_VERSION_MIN}"; then
+        die "Please install Python 3.${OTNS_PYTHON3_VERSION_MIN} or higher, and retry."
+    fi
+fi
 
 # Some basic items are missing on Ubuntu Docker; they're assumed present on MacOS.
 if [[ $Linux == 1 ]]; then
@@ -59,9 +80,6 @@ install_package git --apt git --brew git || true
 
 # Get (first time) or update (after a 'git pull') all submodules.
 git submodule update --init
-
-# Install Go if needed
-install_package go --apt golang --brew golang || true
 
 # Do the rest via the test script, automatically
 ./script/test py-ver-unittests || die "OTNS Installation/tests failed!"

--- a/script/common.sh
+++ b/script/common.sh
@@ -64,13 +64,14 @@ declare -rx GOLINT_ARGS
 OTNS_BUILD_JOBS=$(getconf _NPROCESSORS_ONLN)
 declare -rx OTNS_BUILD_JOBS
 
-# excluded dirs for make-pretty or similar operations
-OTNS_EXCLUDE_DIRS=(ot-rfsim/build/ web/site/node_modules/ pylibs/build/ pylibs/otns/proto/ openthread/ openthread-v11/ openthread-v12/ openthread-v13/ openthread-ccm/)
+# Excluded directories for make-pretty or similar operations
+OTNS_EXCLUDE_DIRS=(ot-rfsim/build/ web/site/node_modules/ pylibs/build/ pylibs/otns/proto/ openthread/
+    ot-rfsim/openthread-v11/ ot-rfsim/openthread-v12/ ot-rfsim/openthread-v13/)
 declare -rx OTNS_EXCLUDE_DIRS
 
 go_install()
 {
-    local pkg=$1
+    local pkg="$1"
     go install "${pkg}" || go get "${pkg}"
 }
 

--- a/script/install-deps
+++ b/script/install-deps
@@ -44,8 +44,8 @@ install_packages()
     install_package wget --apt wget --brew wget || true
     install_package unzip --apt unzip --brew unzip || true
     install_package python3 --apt python3 --brew python3 || true
-    # On Mac, this brew package doesn't exist - not needed.
-    install_package virtualenv --apt python3-venv || true
+    # On MacOS (Darwin), no venv brew package exists - not needed. Use dummy name.
+    install_package virtualenv --apt python3-venv --brew python3 || true
 }
 
 install_grpcwebproxy()

--- a/script/setup-dev
+++ b/script/setup-dev
@@ -48,7 +48,7 @@ while getopts ':u' 'OPTKEY'; do
     esac
 done
 
-function install_protoc()
+install_protoc()
 {
     local protoc_download_url
 


### PR DESCRIPTION
Adds checks for Go and Python3 minimum versions in the bootstrap script. If a version is too low, the script will stop. For Go, it will check if default golang package installation would retrieve a usable version. If it does, the package is installed. If it doesn't, the script will stop.

Also fixes exclude dirs in common.sh.

The current minimum Go version is set to '18' (see first change line in `bootstrap`), and once we update to Go 1.23 this can be set to '23'.

This should help users that install on e.g. a default Ubuntu 24.04 with a Go version < 1.23 to know what to do, instead of running into errors late in the process.