### PR TITLE
[prng][main] show PRNG root seed in log output

### DIFF
--- a/otns_main/otns_main.go
+++ b/otns_main/otns_main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The OTNS Authors.
+// Copyright (c) 2020-2025, The OTNS Authors.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -141,7 +141,7 @@ func Main(ctx *progctx.ProgCtx, cliOptions *cli.CliOptions) {
 	simId, err := parseListenAddr()
 	logger.FatalIfError(err)
 
-	prng.Init(args.RandomSeed)
+	rootSeed := prng.Init(args.RandomSeed)
 	sim, err := createSimulation(simId, ctx)
 	logger.FatalIfError(err)
 
@@ -186,6 +186,8 @@ func Main(ctx *progctx.ProgCtx, cliOptions *cli.CliOptions) {
 	}()
 	<-cli.Cli.Started
 	logger.SetStdoutCallback(cli.Cli)
+
+	logger.Infof("PRNG root seed: %d", rootSeed)
 
 	ctx.WaitAdd("simulation", 1)
 	go func() {

--- a/prng/prng.go
+++ b/prng/prng.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, The OTNS Authors.
+// Copyright (c) 2024-2025, The OTNS Authors.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -39,8 +39,8 @@ var failTimeRandGenerator *rand.Rand
 var unitRandGenerator *rand.Rand
 
 // Init initializes the prng package, either with a fixed PRNG seed (rootSeed != 0) or a 'random' time-based PRNG
-// seed (if rootSeed == 0).
-func Init(rootSeed int64) {
+// seed (if rootSeed == 0). It returns the rootSeed value as used for initializing all PRNGs.
+func Init(rootSeed int64) int64 {
 	if rootSeed == 0 {
 		rootSeed = time.Now().UnixNano()
 	}
@@ -49,6 +49,8 @@ func Init(rootSeed int64) {
 	newRadioModelRandSeedGenerator = rand.New(rand.NewSource(rootSeed + 1))
 	failTimeRandGenerator = rand.New(rand.NewSource(rootSeed + 2))
 	unitRandGenerator = rand.New(rand.NewSource(rootSeed + 3))
+
+	return rootSeed
 }
 
 // NewNodeRandomSeed generates unique random-seeds for newly created nodes.


### PR DESCRIPTION
This adds a log line showing the chosen PRNG root seed. This is useful to reproduce a simulation that was run with a random root seed, or time-based root seed selected by OTNS itself.

Resolves https://github.com/openthread/ot-ns/issues/563