### PR TITLE
[pylibs] Fix random CI test failures in stress-tests and unit-tests 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ Note: this is version 2.x of OTNS. It offers additional features compared to ver
 
 - Support for more accurate RF simulation of OpenThread nodes. This uses the OpenThread platform `ot-rfsim`, which specifically supports RF simulation for OT nodes. This C code is included.
 - Selectable radio (RF propagation) models with tunable RF parameters.
-- Runtime tunable radio parameters on each individual OT node. For example, CSL parameters or Rx sensitivity.
+- Run-time tunable radio parameters on each individual OT node. For example, CSL parameters or Rx sensitivity.
 - Control of logging display from OT-node, using `log` and `watch` CLI commands. Logging to file per OT-node. The logging output can include any enabled OT-node log items.
 - Detailed logging options for RF operations (at log-level 'trace') performed in the simulated radio, at 1 us resolution.
+- Reproducable simulations by selection of a seed value for all pseudo-random number generators.
 - See packets in flight: animations in the GUI with a duration scaled to the actual time duration of a packet in flight (works at low simulation speed only).
 - Support for easily adding various Thread node types (1.1, 1.2, 1.3, 1.4, 1.4 Border Router).
 - New graphical displays for overall node type statistics, and energy usage (beta - contribution by [Vinggui](https://github.com/Vinggui)).

--- a/otns_main/otns_main.go
+++ b/otns_main/otns_main.go
@@ -141,7 +141,7 @@ func Main(ctx *progctx.ProgCtx, cliOptions *cli.CliOptions) {
 	simId, err := parseListenAddr()
 	logger.FatalIfError(err)
 
-	rootSeed := prng.Init(args.RandomSeed)
+	prng.Init(args.RandomSeed)
 	sim, err := createSimulation(simId, ctx)
 	logger.FatalIfError(err)
 
@@ -187,7 +187,7 @@ func Main(ctx *progctx.ProgCtx, cliOptions *cli.CliOptions) {
 	<-cli.Cli.Started
 	logger.SetStdoutCallback(cli.Cli)
 
-	logger.Infof("PRNG root seed: %d", rootSeed)
+	logger.Infof("PRNG root seed: %d", prng.GetRootSeed())
 
 	ctx.WaitAdd("simulation", 1)
 	go func() {
@@ -294,7 +294,7 @@ func createSimulation(simId int, ctx *progctx.ProgCtx) (*simulation.Simulation, 
 			}
 		}
 	}
-	simcfg.RandomSeed = prng.RandomSeed(args.RandomSeed)
+	simcfg.RandomSeed = prng.GetRootSeed()
 
 	dispatcherCfg := dispatcher.DefaultConfig()
 	dispatcherCfg.SimulationId = simcfg.Id

--- a/prng/prng.go
+++ b/prng/prng.go
@@ -37,20 +37,26 @@ var newNodeRandSeedGenerator *rand.Rand
 var newRadioModelRandSeedGenerator *rand.Rand
 var failTimeRandGenerator *rand.Rand
 var unitRandGenerator *rand.Rand
+var rootSeed int64
 
 // Init initializes the prng package, either with a fixed PRNG seed (rootSeed != 0) or a 'random' time-based PRNG
-// seed (if rootSeed == 0). It returns the rootSeed value as used for initializing all PRNGs.
-func Init(rootSeed int64) int64 {
-	if rootSeed == 0 {
+// seed (if rootSeed == 0).
+func Init(rootSeedInit int64) {
+	if rootSeedInit == 0 {
 		rootSeed = time.Now().UnixNano()
+	} else {
+		rootSeed = rootSeedInit
 	}
 
 	newNodeRandSeedGenerator = rand.New(rand.NewSource(rootSeed))
 	newRadioModelRandSeedGenerator = rand.New(rand.NewSource(rootSeed + 1))
 	failTimeRandGenerator = rand.New(rand.NewSource(rootSeed + 2))
 	unitRandGenerator = rand.New(rand.NewSource(rootSeed + 3))
+}
 
-	return rootSeed
+// GetRootSeed returns the root seed last used to initialize the prng package.
+func GetRootSeed() RandomSeed {
+	return RandomSeed(rootSeed)
 }
 
 // NewNodeRandomSeed generates unique random-seeds for newly created nodes.


### PR DESCRIPTION
This constrains the randomness in radio models for certain cases, by selecting a known random seed for the PRNGs.
It updates BaseStressTest by making the Python script's random values also governed by the root seed.
In testWifiInterferers, the run duration is made longer to handle cases where the Partition only fully forms
after all nodes are upgraded to Router role.

The PR requires PR #577 to work. (Not included here!)