### PR TITLE
[pylibs] fix random CI test failures

### DIFF
--- a/pylibs/stress_tests/BaseStressTest.py
+++ b/pylibs/stress_tests/BaseStressTest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2020-2023, The OTNS Authors.
+# Copyright (c) 2020-2025, The OTNS Authors.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -26,8 +26,11 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
+# Base class for all stress-tests.
+
 import ipaddress
 import os
+import random
 import sys
 import time
 import traceback
@@ -68,13 +71,19 @@ class StressTestMetaclass(type):
 
 class BaseStressTest(object, metaclass=StressTestMetaclass):
 
-    def __init__(self, name, headers, web=True, raw=False, rand_seed=0):
+    def __init__(self, name, headers, web=True, raw=False, rand_seed=None):
         self.name = name
-        self._otns_args = ['-log', 'info', '-logfile', 'none', '-seed',
-                           str(rand_seed)]  # use ['-log', 'debug'] for more debug messages
+        self._otns_args = ['-log', 'info', '-logfile', 'none']  # change to ['-log', 'debug'] for more messages
+
         if raw:
             self._otns_args.append('-ot-script')
             self._otns_args.append('none')
+
+        if rand_seed is not None:
+            random.seed(rand_seed)  # if PRNG seed given, use same seed for Python script
+            self._otns_args.append('-seed')
+            self._otns_args.append(str(rand_seed))
+
         self.ns = OTNS(otns_args=self._otns_args)
         self.ns.speed = float('inf')
         if web:

--- a/pylibs/stress_tests/network_latency.py
+++ b/pylibs/stress_tests/network_latency.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2020-2023, The OTNS Authors.
+# Copyright (c) 2020-2025, The OTNS Authors.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -34,9 +34,10 @@
 # Fault Injections:
 #   None
 # Pass Criteria:
-#   Max ping latency < (3 * datasize + 500 * (datasize>=128)) ms
+#   Max ping latency <= (3 * datasize + 500 * (datasize>=128)) ms
 #   (for fragmented ping messages there's an added 500 ms to cater for fragment losses, MAC retries, hidden node
 #    situations, etc.)
+
 import logging
 import math
 
@@ -57,11 +58,13 @@ class StressTest(BaseStressTest):
 
     def __init__(self):
         super(StressTest, self).__init__("Ping Latency Test",
-                                         ["Data Size", "Hop x1 Latency", "Hop x2 Latency", "Hop x3 Latency"])
+                                         ["Data Size", "Hop x1 Latency", "Hop x2 Latency", "Hop x3 Latency"],
+                                         rand_seed=0xF0B0)
 
         self._ping_latencys_by_datasize = {}
         self.ns.loglevel = 'warn'
         self.ns.radiomodel = 'MIDisc'
+        self.ns.config_visualization(broadcast_message=False)
         self.ns.set_title("Network (Ping) Latency test - setup phase")
 
     def add_6_nodes(self, x, y, start_angle):

--- a/pylibs/stress_tests/network_limits.py
+++ b/pylibs/stress_tests/network_limits.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2022-2024, The OTNS Authors.
+# Copyright (c) 2022-2025, The OTNS Authors.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -26,6 +26,9 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
+# Test that all Children attach to the single Parent within the time limit.
+# Different Parent and Child types are tested.
+
 import logging
 import math
 import random
@@ -36,7 +39,8 @@ PARENT_X = 500
 PARENT_Y = 500
 MAX_DISTANCE = 200
 CHILDREN_N = 10
-CHILDREN_N_BR = 32
+CHILDREN_N_BR = 32  # The BR supports a higher number of Children.
+PRNG_SEED = 0x782EAD
 
 
 class StressTest(BaseStressTest):
@@ -60,7 +64,10 @@ class StressTest(BaseStressTest):
     }
 
     def __init__(self):
-        super(StressTest, self).__init__("Parent with max Children count", [])
+        # Use a fixed root PRNG seed for simulation, to avoid random RF coverage white spots
+        # in the radio model.
+        super(StressTest, self).__init__("Parent with max Children count", [], rand_seed=PRNG_SEED)
+        self.ns.log = 'debug'
 
     def run(self):
         self.ns.speed = 30  # speed is lowered to see the visualization, when run locally.
@@ -77,8 +84,6 @@ class StressTest(BaseStressTest):
 
     def test(self, child_type: str, parent_type: str, n_children_max: int = CHILDREN_N):
         self.reset()
-        self.ns.log = 'debug'
-        #self.ns.watch_default('trace') # can enable trace level to see radio state details
         self.ns.add(parent_type, PARENT_X, PARENT_Y)
         self.ns.go(7)
 

--- a/pylibs/unittests/test_exe_versions.py
+++ b/pylibs/unittests/test_exe_versions.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2023-2024, The OTNS Authors.
+# Copyright (c) 2023-2025, The OTNS Authors.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -25,6 +25,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
+
 import unittest
 
 from OTNSTestCase import OTNSTestCase
@@ -39,6 +40,7 @@ class ExeVersionTests(OTNSTestCase):
 
     def testAddNodeWrongExecutable(self):
         ns: OTNS = self.ns
+
         ns.add('router')
         ns.go(5)
         self.assertEqual(1, len(ns.nodes()))
@@ -50,6 +52,7 @@ class ExeVersionTests(OTNSTestCase):
 
     def testExe(self):
         ns: OTNS = self.ns
+
         nid = ns.add('router')
         self.assertTrue(ns.get_thread_version(nid) >= 4)
         ns.go(10)
@@ -95,6 +98,7 @@ class ExeVersionTests(OTNSTestCase):
 
     def testAddVersionNodes(self):
         ns: OTNS = self.ns
+
         ns.add('router', x=250, y=250)
         ns.go(10)
         nid = ns.add('router', version='v14')
@@ -113,7 +117,7 @@ class ExeVersionTests(OTNSTestCase):
         self.assertEqual(1, len(ns.partitions()))
 
     def testSsedVersions(self):
-        ns = self.ns
+        ns: OTNS = self.ns
 
         ns.add("router", 100, 100)
         ns.go(10)
@@ -138,12 +142,16 @@ class ExeVersionTests(OTNSTestCase):
 
     def testWifiInterferers(self):
         ns: OTNS = self.ns
+
         ns.add('router')
         ns.add('router')
         ns.add('router')
         ns.add('wifi')
-        ns.go(50)
-        # the wifi node stays on partition 0 (Thread is disabled)
+        ns.cmd('rfsim 4 txintf 90')  # interfering signal 90% of the time
+        ns.go(150)
+
+        # Thread nodes form a Partition.
+        # The wifi node stays on partition 0 (Thread is disabled)
         self.assertEqual(2, len(ns.partitions()))
 
 


### PR DESCRIPTION
This constrains the randomness in radio models for certain cases, by selecting a known random seed for the PRNGs.
It fixes reproducability in BaseStressTest by making the Python script's random values also governed by the root seed.
In testWifiInterferers, the randomness is kept but the run duration is made longer to handle cases where the Partition only fully forms after all nodes are upgraded to Router role.

Note: this replaces the old PR https://github.com/openthread/ot-ns/pull/579 , where something went wrong during rebasing.

Closes #559