### PR TITLE
[simulation] node auto-placer places End Devices in rows

### DIFF
--- a/simulation/node_config.go
+++ b/simulation/node_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The OTNS Authors.
+// Copyright (c) 2020-2025, The OTNS Authors.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -333,10 +333,13 @@ func (nap *NodeAutoPlacer) UpdateReference(x, y, z int) {
 // NextNodePosition lets the autoplacer pick the next position for a new node to be placed.
 func (nap *NodeAutoPlacer) NextNodePosition(isBelowParent bool) (int, int, int) {
 	var x, y, z int
+	var fineCountCol, fineCountRow int
 
 	if isBelowParent {
-		y = nap.Y + nap.NodeDeltaCoarse/2
-		x = nap.X + nap.fineCount*nap.NodeDeltaFine - nap.NodeDeltaFine
+		fineCountCol = nap.fineCount % 16
+		fineCountRow = nap.fineCount / 16
+		y = nap.Y + (nap.NodeDeltaCoarse/2)*(fineCountRow+1)
+		x = nap.X + (fineCountCol*nap.NodeDeltaFine - nap.NodeDeltaFine)
 		nap.fineCount++
 	} else {
 		if !nap.isReset {


### PR DESCRIPTION
Enhances the node auto-placer, which gets used when adding nodes without X/Y/Z coordinate input. When more than 16 End Devices (Children) are added, a new row of End Devices is started. This avoids the End Devices quickly being placed beyond the visible coordinates of the Web GUI.