### PR TITLE
[ot-rfsim] patch for legacy OT builds - increase CMake version

### DIFF
--- a/ot-rfsim/etc/v11.patch
+++ b/ot-rfsim/etc/v11.patch
@@ -1,17 +1,23 @@
-From 5b77e200f648c36787109eebf4bb97380cc06960 Mon Sep 17 00:00:00 2001
-From: Esko Dijk <esko.dijk@iotconsultancy.nl>
-Date: Fri, 5 Jul 2024 10:51:51 +0200
-Subject: [PATCH] [OTNS] remove -Werror build flag in [mbedtls] to enable
- building legacy code on newer (Apple Clang) compilers.
+# Subject: [PATCH] [OTNS] remove -Werror build flag in [mbedtls] to enable
+# building legacy code on newer (Apple Clang) compilers.
+# Also sets the minimum CMake version for mbedtls from 2.8.12 to 3.5.1, so
+# that a newer CMake (4.x) can still build the library.
+# This patch was made for commit 0a5152b4fa9f9cbff57da89d9aa33d409e915241 (v11)
 
----
- third_party/mbedtls/repo/CMakeLists.txt | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/third_party/mbedtls/repo/CMakeLists.txt b/third_party/mbedtls/repo/CMakeLists.txt
-index ac24bf41b..eef0a9260 100644
+index ac24bf41b..508bbfba7 100644
 --- a/third_party/mbedtls/repo/CMakeLists.txt
 +++ b/third_party/mbedtls/repo/CMakeLists.txt
+@@ -20,7 +20,7 @@
+ #   mbedtls, mbedx509, mbedcrypto and apidoc targets.
+ #
+
+-cmake_minimum_required(VERSION 2.8.12)
++cmake_minimum_required(VERSION 3.5.1)
+ if(TEST_CPP)
+     project("mbed TLS" C CXX)
+ else()
 @@ -218,7 +218,7 @@ if(MBEDTLS_FATAL_WARNINGS)
      endif(CMAKE_COMPILER_IS_MSVC)
 
@@ -21,5 +27,3 @@ index ac24bf41b..eef0a9260 100644
          if(UNSAFE_BUILD)
              set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error=cpp")
              set(CMAKE_C_FLAGS_ASAN "${CMAKE_C_FLAGS_ASAN} -Wno-error=cpp")
---
-2.34.1

--- a/ot-rfsim/etc/v12.patch
+++ b/ot-rfsim/etc/v12.patch
@@ -1,0 +1,29 @@
+# Subject: [PATCH] [OTNS] remove -Werror build flag in [mbedtls] to enable
+# building legacy code on newer (Apple Clang) compilers.
+# Also sets the minimum CMake version for mbedtls from 2.8.12 to 3.5.1, so
+# that a newer CMake (4.x) can still build the library.
+# This patch was made for commit f759d163dc4e719bc2dbdf0bc713ea33d51b1819 (v12)
+
+
+diff --git a/third_party/mbedtls/repo/CMakeLists.txt b/third_party/mbedtls/repo/CMakeLists.txt
+index ac24bf41b..508bbfba7 100644
+--- a/third_party/mbedtls/repo/CMakeLists.txt
++++ b/third_party/mbedtls/repo/CMakeLists.txt
+@@ -20,7 +20,7 @@
+ #   mbedtls, mbedx509, mbedcrypto and apidoc targets.
+ #
+
+-cmake_minimum_required(VERSION 2.8.12)
++cmake_minimum_required(VERSION 3.5.1)
+ if(TEST_CPP)
+     project("mbed TLS" C CXX)
+ else()
+@@ -218,7 +218,7 @@ if(MBEDTLS_FATAL_WARNINGS)
+     endif(CMAKE_COMPILER_IS_MSVC)
+
+     if(CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_GNU)
+-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
++        # set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+         if(UNSAFE_BUILD)
+             set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error=cpp")
+             set(CMAKE_C_FLAGS_ASAN "${CMAKE_C_FLAGS_ASAN} -Wno-error=cpp")

--- a/ot-rfsim/etc/v13.patch
+++ b/ot-rfsim/etc/v13.patch
@@ -1,0 +1,29 @@
+# Subject: [PATCH] [OTNS] remove -Werror build flag in [mbedtls] to enable
+# building legacy code on newer (Apple Clang) compilers.
+# Also sets the minimum CMake version for mbedtls from 2.8.12 to 3.5.1, so
+# that a newer CMake (4.x) can still build the library.
+# This patch was made for commit c6179c24ed75a11c14dc4b1fffcde58be0bda785 (v13).
+
+
+diff --git a/third_party/mbedtls/repo/CMakeLists.txt b/third_party/mbedtls/repo/CMakeLists.txt
+index 14ca7b696..7c90dedcb 100644
+--- a/third_party/mbedtls/repo/CMakeLists.txt
++++ b/third_party/mbedtls/repo/CMakeLists.txt
+@@ -20,7 +20,7 @@
+ #   mbedtls, mbedx509, mbedcrypto and apidoc targets.
+ #
+ 
+-cmake_minimum_required(VERSION 2.8.12)
++cmake_minimum_required(VERSION 3.5.1)
+ 
+ # https://cmake.org/cmake/help/latest/policy/CMP0011.html
+ # Setting this policy is required in CMake >= 3.18.0, otherwise a warning is generated. The OLD
+@@ -236,7 +236,7 @@ if(MBEDTLS_FATAL_WARNINGS)
+     endif(CMAKE_COMPILER_IS_MSVC)
+ 
+     if(CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_GNU)
+-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
++        # set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+         if(UNSAFE_BUILD)
+             set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error=cpp")
+             set(CMAKE_C_FLAGS_ASAN "${CMAKE_C_FLAGS_ASAN} -Wno-error=cpp")

--- a/ot-rfsim/script/build_v11
+++ b/ot-rfsim/script/build_v11
@@ -46,7 +46,7 @@ main()
     options+=("${OT_OPTIONS[@]}" "$@")
 
     if [[ ! -f ./openthread-v11/README.md ]]; then
-        get_openthread_commit "0a5152b4fa9f9cbff57da89d9aa33d409e915241" "./openthread-v11" "../openthread"
+        get_openthread_commit "0a5152b4fa9f9cbff57da89d9aa33d409e915241" "./openthread-v11" "../openthread" "v11"
     fi
 
     OT_DIR="./openthread-v11" OTNS_NODE_TYPE="v11" OT_CMAKE_NINJA_TARGET="ot-cli-ftd ot-cli-mtd" ./script/build "${options[@]}"

--- a/ot-rfsim/script/build_v12
+++ b/ot-rfsim/script/build_v12
@@ -47,7 +47,7 @@ main()
     options+=("${OT_OPTIONS[@]}" "$@")
 
     if [[ ! -f ./openthread-v12/README.md ]]; then
-        get_openthread_commit "f759d163dc4e719bc2dbdf0bc713ea33d51b1819" "./openthread-v12" "../openthread"
+        get_openthread_commit "f759d163dc4e719bc2dbdf0bc713ea33d51b1819" "./openthread-v12" "../openthread" "v12"
     fi
 
     OT_DIR="./openthread-v12" OTNS_NODE_TYPE="v12" OT_CMAKE_NINJA_TARGET="ot-cli-ftd ot-cli-mtd" ./script/build "${options[@]}"

--- a/ot-rfsim/script/build_v13
+++ b/ot-rfsim/script/build_v13
@@ -59,7 +59,7 @@ main()
     options+=("${OT_OPTIONS[@]}" "$@")
 
     if [[ ! -f ./openthread-v13/README.md ]]; then
-        get_openthread_commit "c6179c24ed75a11c14dc4b1fffcde58be0bda785" "./openthread-v13" "../openthread"
+        get_openthread_commit "c6179c24ed75a11c14dc4b1fffcde58be0bda785" "./openthread-v13" "../openthread" "v13"
     fi
 
     OT_DIR="./openthread-v13" OTNS_NODE_TYPE="v13" OT_CMAKE_NINJA_TARGET="ot-cli-ftd ot-cli-mtd" ./script/build "${options[@]}"

--- a/script/utils.sh
+++ b/script/utils.sh
@@ -206,6 +206,8 @@ get_openthread_commit()
     local commit="${1}"
     local ot_commit_dir="${2}"
     local ot_dir="${3}"
+    local patch_id="${4}"
+
     ot_commit_dir=$(realpathf "${ot_commit_dir}")
     ot_dir=$(realpathf "${ot_dir}")
     mkdir -p "${ot_commit_dir}"
@@ -213,6 +215,6 @@ get_openthread_commit()
         cd "${ot_dir}" || die "OpenThread directory not found: ${ot_dir}"
         git archive --format=tar "${commit}" | tar -x -C "${ot_commit_dir}"
         cd "${ot_commit_dir}" || die "OpenThread target directory for commit not found: ${ot_commit_dir}"
-        patch -p1 <../etc/ot-mbedtls-settings.patch
+        patch -p1 <../etc/"${patch_id}".patch
     )
 }


### PR DESCRIPTION
Increasing the version to 3.5.1, for the mbedtls repo, will support CMake 4.x