### PR TITLE
[cli][pylibs][simulation] allow fractional ping intervals and conform to OT ping defaults

### DIFF
--- a/cli/CmdRunner.go
+++ b/cli/CmdRunner.go
@@ -512,10 +512,10 @@ func (rt *CmdRunner) executePing(cc *CommandContext, cmd *PingCmd) {
 			dstaddr = cmd.DstAddr.Addr
 		}
 
-		datasize := 4 // Note: must be at least 4 otherwise OTNS will ignore ping req/resp for stats.
+		datasize := 8 // Note: must be at least 4 otherwise OTNS will ignore ping req/resp for stats.
 		count := 1
-		interval := 10
-		hopLimit := 64
+		interval := 1.0 // seconds
+		hopLimit := 64  // default IPv6 ping hop limit
 
 		if cmd.DataSize != nil {
 			datasize = cmd.DataSize.Val

--- a/cli/README.md
+++ b/cli/README.md
@@ -596,14 +596,23 @@ NOTE: Sleepy End Devices (SEDs) typically don't respond to a ping request, while
 ```bash
 > ping 1 2
 Done
+Node<1>  16 bytes from fdde:ad00:beef:0:d17a:df54:589b:767a: icmp_seq=1 hlim=64 time=22ms
+Node<1>  1 packets transmitted, 1 packets received. Packet loss = 0.0%. Round-trip min/avg/max = 22/22.000/22 ms.
 > ping 1 2 rloc
+(...)
 Done
 > ping 1 2 mleid
+(...)
 Done
 > ping 1 "fdde:ad00:beef:0:31d6:8873:f685:9c40"
 Done
-> ping 1 2 datasize 10 count 3 interval 1 hoplimit 10
+Node<1>  1 packets transmitted, 0 packets received. Packet loss = 100.0%.
+> ping 1 2 datasize 10 count 3 interval 1.5 hoplimit 10
 Done
+Node<1>  18 bytes from fdde:ad00:beef:0:d17a:df54:589b:767a: icmp_seq=5 hlim=64 time=6ms
+Node<1>  18 bytes from fdde:ad00:beef:0:d17a:df54:589b:767a: icmp_seq=6 hlim=64 time=6ms
+Node<1>  18 bytes from fdde:ad00:beef:0:d17a:df54:589b:767a: icmp_seq=7 hlim=64 time=13ms
+Node<1>  3 packets transmitted, 3 packets received. Packet loss = 0.0%. Round-trip min/avg/max = 6/8.333/13 ms.
 ```
 
 ### pings
@@ -612,11 +621,12 @@ Display finished ping sessions.
 
 ```bash
 > ping 1 2 count 3
+(...)
 Done
 > pings
-node=1    dst=fdde:ad00:beef:0:31d6:8873:f685:9c40     datasize=4   delay=0.322ms
-node=1    dst=fdde:ad00:beef:0:31d6:8873:f685:9c40     datasize=4   delay=2.242ms
-node=1    dst=fdde:ad00:beef:0:31d6:8873:f685:9c40     datasize=4   delay=1.282ms
+node=1    dst=fdde:ad00:beef:0:d17a:df54:589b:767a     datasize=8   delay=8.884ms
+node=1    dst=fdde:ad00:beef:0:d17a:df54:589b:767a     datasize=8   delay=4.944ms
+node=1    dst=fdde:ad00:beef:0:d17a:df54:589b:767a     datasize=8   delay=9.424ms
 Done
 ```
 

--- a/cli/ast.go
+++ b/cli/ast.go
@@ -173,7 +173,7 @@ type DataSizeFlag struct {
 
 // noinspection GoVetStructTag
 type IntervalFlag struct {
-	Val int `("interval"|"itv") @Int` //nolint
+	Val float64 `("interval"|"itv") (@Int|@Float)` //nolint
 }
 
 // noinspection GoVetStructTag

--- a/pylibs/otns/cli/OTNS.py
+++ b/pylibs/otns/cli/OTNS.py
@@ -579,9 +579,9 @@ class OTNS(object):
              srcid: int,
              dst: Union[int, str, ipaddress.IPv6Address],
              addrtype: str = 'any',
-             datasize: int = 4,
+             datasize: int = 8,
              count: int = 1,
-             interval: float = 10) -> None:
+             interval: float = 1.0) -> None:
         """
         Ping from source node to destination node.
 
@@ -590,7 +590,7 @@ class OTNS(object):
         :param addrtype: address type for the destination node (only useful for destination node ID)
         :param datasize: ping data size; WARNING - data size < 4 is ignored by OTNS.
         :param count: ping count
-        :param interval: ping interval (in seconds), also the max acceptable ping RTT before giving up.
+        :param interval: ping interval (in seconds)
 
         Use pings() to get ping results.
         """

--- a/pylibs/setup.py
+++ b/pylibs/setup.py
@@ -29,7 +29,7 @@ import setuptools
 
 setuptools.setup(
     name="pyOTNS",
-    version="2.1.1",
+    version="2.1.2",
     author="The OTNS Authors",
     description="Run OTNS2 OpenThread mesh network simulations from Python code",
     url="https://github.com/openthread/ot-ns",

--- a/simulation/node.go
+++ b/simulation/node.go
@@ -766,8 +766,8 @@ func (node *Node) Reset() {
 	node.Logger.Warn("reset complete")
 }
 
-func (node *Node) Ping(addr string, payloadSize int, count int, interval int, hopLimit int) {
-	cmd := fmt.Sprintf("ping async %s %d %d %d %d", addr, payloadSize, count, interval, hopLimit)
+func (node *Node) Ping(addr string, payloadSize int, count int, interval float64, hopLimit int) {
+	cmd := fmt.Sprintf("ping async %s %d %d %f %d", addr, payloadSize, count, interval, hopLimit)
 	err := node.inputCommand(cmd)
 	if err != nil {
 		node.error(err)


### PR DESCRIPTION
This fixes the OTNS CLI to enable fractional numbers for ping interval, as supported by OT. Also conforms default values to OT's defaults: interval = 1.0, ping size = 8B. Fixes Pylibs API description for 'interval' parameter which was incorrect. Help text for 'ping' fixes to show actual output.