### PR TITLE
[ot-rfsim] enable TCAT Commissioner access to OTNS node over UDP port (10000 + gNodeId)

### DIFF
--- a/dispatcher/Node.go
+++ b/dispatcher/Node.go
@@ -190,7 +190,7 @@ func (node *Node) sendEvent(evt *Event) {
 		reEvaluateTime, isUpdated := node.failureCtrl.OnTimeAdvanced(oldTime)
 		if isUpdated {
 			wakeEvt := &Event{
-				Type:      EventTypeAlarmFired,
+				Type:      EventTypeScheduleNode,
 				NodeId:    node.Id,
 				Timestamp: reEvaluateTime,
 			}

--- a/event/event.go
+++ b/event/event.go
@@ -43,7 +43,7 @@ type EventType = uint8
 const (
 	// Event type IDs (external, shared between OT-NS and OT node)
 	EventTypeAlarmFired         EventType = 0
-	EventTypeRadioReceived      EventType = 1
+	EventTypeScheduleNode       EventType = 1
 	EventTypeUartWrite          EventType = 2
 	EventTypeRadioSpinelWrite   EventType = 3
 	EventTypePostCmd            EventType = 4
@@ -319,14 +319,3 @@ func (e *Event) String() string {
 	s := fmt.Sprintf("Ev{%2d,nid=%d,mid=%d,dly=%v%s}", e.Type, e.NodeId, e.MsgId, e.Delay, paylStr)
 	return s
 }
-
-/*
-func keepPrintableChars(s string) string {
-	return strings.Map(func(r rune) rune {
-		if unicode.IsPrint(r) {
-			return r
-		}
-		return -1
-	}, s)
-}
-*/

--- a/ot-rfsim/src/alarm.c
+++ b/ot-rfsim/src/alarm.c
@@ -236,7 +236,7 @@ void platformAlarmProcess(otInstance *aInstance)
 #endif // OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
 }
 
-uint64_t otPlatTimeGet(void) { return platformAlarmGetNow(); }
+uint64_t otPlatTimeGet(void) { return sNow; }
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 uint16_t otPlatTimeGetXtalAccuracy(void) { return 0; }

--- a/ot-rfsim/src/event-sim.h
+++ b/ot-rfsim/src/event-sim.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020-2024, The OpenThread Authors.
+ *  Copyright (c) 2020-2025, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -48,7 +48,7 @@
 enum
 {
     OT_SIM_EVENT_ALARM_FIRED        = 0,
-    OT_SIM_EVENT_RADIO_RECEIVED     = 1, // legacy
+    OT_SIM_EVENT_SCHEDULE_NODE      = 1,
     OT_SIM_EVENT_UART_WRITE         = 2,
     OT_SIM_EVENT_RADIO_SPINEL_WRITE = 3, // not used?
     OT_SIM_EVENT_POSTCMD            = 4, // not used?
@@ -139,28 +139,41 @@ struct MsgToHostEventData
 void otSimSendEvent(struct Event *aEvent);
 
 /**
- * Send a sleep event to the simulator. The amount of time to sleep
- * for this node is determined by the alarm timer, by calling platformAlarmGetNext().
- *
+ * Send a sleep event to the simulator. The amount of time to request to sleep
+ * for this node is determined by the OT alarm timer, by calling platformAlarmGetNext().
+ * The simulator will use this value to update the AlarmManager that keeps track of alarms set
+ * for all nodes.
  */
 void otSimSendSleepEvent(void);
 
 /**
+ * Send a schedule-node event to the simulator. This signals a future point in time when the node
+ * needs to process again. This function can be called multiple times. The set times
+ * are independent of the next alarm time, which is the time that the OT stack needs to
+ * process again. Schedule events are used for platform-specific things such as state transitions
+ * of the simulated radio chip that are not under OT control.
+ *
+ * @param[in]  aDelayUs    A delay in us indicating when, counted from current time,
+ *                         the node needs to process again.
+ */
+void otSimSendScheduleNodeEvent(uint64_t aDelayUs);
+
+/**
  * Sends a RadioComm (Tx) simulation event to the simulator.
  *
- * @param[in]       aEventData A pointer to specific data for RadioComm event.
- * @param[in]       aPayload     A pointer to the data payload (radio frame) to send.
- * @param[in]       aLenPayload  Length of aPayload data.
+ * @param[in]  aEventData   A pointer to specific data for RadioComm event.
+ * @param[in]  aPayload     A pointer to the data payload (radio frame) to send.
+ * @param[in]  aLenPayload  Length of aPayload data.
  */
-void otSimSendRadioCommEvent(struct RadioCommEventData *aEventData, const uint8_t *aPayload, size_t aLenPayload);
+void otSimSendRadioCommEvent(const struct RadioCommEventData *aEventData, const uint8_t *aPayload, size_t aLenPayload);
 
 /**
  * Sends a RadioComm (Tx) simulation event to the simulator for transmitting non-802.15.4
  * interference signals.
  *
- * @param[in] aEventData A pointer to specific data for the event.
+ * @param[in]  aEventData   A pointer to specific data for the event.
  */
-void otSimSendRadioCommInterferenceEvent(struct RadioCommEventData *aEventData);
+void otSimSendRadioCommInterferenceEvent(const struct RadioCommEventData *aEventData);
 
 /**
  * Send a Radio State simulation event to the simulator. It reports radio state
@@ -169,7 +182,7 @@ void otSimSendRadioCommInterferenceEvent(struct RadioCommEventData *aEventData);
  * @param[in]  aStateData                 A pointer to specific data for Radio State event.
  * @param[in]  aDeltaUntilNextRadioState  Time (us) until next radio-state change event, or UNDEFINED_TIME_US.
  */
-void otSimSendRadioStateEvent(struct RadioStateEventData *aStateData, uint64_t aDeltaUntilNextRadioState);
+void otSimSendRadioStateEvent(const struct RadioStateEventData *aStateData, uint64_t aDeltaUntilNextRadioState);
 
 /**
  * Send a channel sample simulation event to the simulator. It is used both
@@ -177,7 +190,7 @@ void otSimSendRadioStateEvent(struct RadioStateEventData *aStateData, uint64_t a
  *
  * @param[in]  aChanData    A pointer to channel-sample data instructing what to sample.
  */
-void otSimSendRadioChanSampleEvent(struct RadioCommEventData *aChanData);
+void otSimSendRadioChanSampleEvent(const struct RadioCommEventData *aChanData);
 
 /**
  * Send a UART data event to the simulator.
@@ -233,6 +246,9 @@ void otSimSendRfSimParamRespEvent(uint8_t param, int32_t value);
  * @param aMsgBytes  the bytes of the message itself (e.g. UDP packet bytes or IPv6 datagram bytes)
  * @param aMsgLen    the length of the message
  */
-void otSimSendMsgToHostEvent(uint8_t evType, struct MsgToHostEventData *aEventData, uint8_t *aMsgBytes, size_t aMsgLen);
+void otSimSendMsgToHostEvent(uint8_t                          evType,
+                             const struct MsgToHostEventData *aEventData,
+                             const uint8_t                   *aMsgBytes,
+                             size_t                           aMsgLen);
 
 #endif // PLATFORM_RFSIM_EVENT_SIM_H

--- a/ot-rfsim/src/platform-rfsim.c
+++ b/ot-rfsim/src/platform-rfsim.c
@@ -115,7 +115,8 @@ void platformReceiveEvent(otInstance *aInstance)
     switch (event.mEvent)
     {
     case OT_SIM_EVENT_ALARM_FIRED:
-        // Alarm events may be used to wake the node again when some simulated time has passed.
+    case OT_SIM_EVENT_SCHEDULE_NODE:
+        // Alarm or schedule-node events may be used to wake the node again when some simulated time has passed.
         break;
 
     case OT_SIM_EVENT_UART_WRITE:

--- a/ot-rfsim/src/radio.h
+++ b/ot-rfsim/src/radio.h
@@ -36,6 +36,7 @@
 
 // platform-specific OT_ERROR status code to indicate an interference Tx
 #define OT_TX_TYPE_INTF 192
+#define OT_TX_TYPE_BLE_ADV 193
 
 // IEEE 802.15.4 related parameters. See radio-parameters.h for radio-model-specific parameters.
 enum

--- a/simulation/node.go
+++ b/simulation/node.go
@@ -1100,6 +1100,10 @@ func (node *Node) expectEvent(evtType event.EventType, timeout time.Duration) (*
 			return nil, err
 		case evt := <-node.pendingEvents:
 			node.Logger.Tracef("expectEvent() received: %v", evt)
+			if evt.Type != evtType {
+				err := fmt.Errorf("expectEvent: expected type %d, but got %d", evtType, evt.Type)
+				return nil, err
+			}
 			return evt, nil
 		default:
 			if !node.S.Dispatcher().IsAlive(node.Id) {

--- a/types/ot_types.go
+++ b/types/ot_types.go
@@ -36,10 +36,11 @@ const (
 // OT_ERROR_* error codes from OpenThread that can be sent by OT-NS to the OT nodes.
 // (See OpenThread error.h for details)
 const (
-	OT_ERROR_NONE   = 0
-	OT_ERROR_ABORT  = 11
-	OT_ERROR_FCS    = 17
-	OT_TX_TYPE_INTF = 192 // special status used for interference signals Tx
+	OT_ERROR_NONE      = 0
+	OT_ERROR_ABORT     = 11
+	OT_ERROR_FCS       = 17
+	OT_TX_TYPE_INTF    = 192 // special status used for interference signals Tx
+	OT_TX_TYPE_BLE_ADV = 193 // special status used for BLE adv signals Tx
 )
 
 const (


### PR DESCRIPTION
This is a testing mechanism for TCAT commissioning. The access via UDP bypasses the virtual-time simulation events, so that current TCAT/BLE Commissioner in UDP simulation mode can be used unmodified.

For a future update we may consider sending the BLE packets between Commissioner and Device as simulated radio traffic, over a "BLE" channel, like currently the BLE advertisements are sent. But that is more complex and requires the TCAT Commissioner to generate events into the simulator.