### PR TITLE
[github-actions] update deprecated macos-13 for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
       matrix:
         go: [ '1.23' ]
-        os: [ ubuntu-22.04, ubuntu-24.04, macos-13, macos-14 ]
+        os: [ ubuntu-22.04, ubuntu-24.04, macos-14, macos-15 ]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
@@ -66,7 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, ubuntu-24.04, macos-13, macos-14 ]
+        os: [ ubuntu-22.04, ubuntu-24.04, macos-14, macos-15 ]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
@@ -83,7 +83,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, ubuntu-24.04, macos-13, macos-14 ]
+        os: [ ubuntu-22.04, ubuntu-24.04, macos-14, macos-15 ]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Bootstrap


### PR DESCRIPTION
GitHub deprecates the macos-13 runner in Nov 2025. This updates version 13/14 to 14/15.
See: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/
