### PR TITLE
[cli][ot-rfsim][simulation][types] add 'bitrate' radio parameter / enable defaults for radio parameters

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -765,12 +765,16 @@ Done
 Get or set parameters of a node's (OT-RFSIM node) simulated radio.
 
 ```shell
+rfsim
 rfsim <node-id>
 rfsim <node-id> <param-name>
 rfsim <node-id> <param-name> <new-value>
+rfsim default
+rfsim default <param-name>
+rfsim default <param-name> <new-value>
 ```
 
-Use with the `node-id` argument to get a list of all current OT-RFSIM radio parameters for that node. Add the `param-name` to get only the value of that parameter. If both `param-name` and `new-value` are provided, the parameter value is set to `new-value`. It has to be a numeric value (int).
+Use `rfsim` without arguments to display the current simulated radio parameters that are available for operations. Use with the `node-id` argument to get a list of all current OT-RFSIM radio parameters and their values for that node. Add the `param-name` to get only the value of that parameter. If both `param-name` and `new-value` are provided, the parameter value is set to `new-value`. It has to be a numeric value (int).
 
 In a physical radio platform, most of these parameters are typically fixed. In a simulation, these can be changed to explore different radios or different scenarios.
 
@@ -781,9 +785,12 @@ The following parameters are supported:
 - `cslacc` - 802.15.4 Coordinated Sampled Listening (CSL) accuracy in ppm, range 0-255.
 - `cslunc` - 802.15.4 CSL uncertainty in units of 10 microsec, range 0-255.
 - `txintf` - for the `wifi` node type, sets the percentage of Wi-Fi traffic, range 0 to 100. Must not be >0 on other node types.
-- `clkdrift` - clock drift of the node's timers in ppm, in the range -127 to 127.
+- `clkdrift` - clock drift of the node's timers in ppm, in the range -32768 to +32767.
+- `bitrate` - 802.15.4 PHY bitrate in bps, in the range 1 to 2147483646.
 
 NOTE: To change global radio model parameters for all nodes, use the [radioparam](#radioparam) command.
+
+Use `rfsim default` to display the current default radio model parameters that have been set for any new node that is created. If nothing has been explicitly set, this list is empty. In this case all rfsim parameters are determined automatically by the OT-RFSIM node itself. By using `rfsim default <param-name> <new-value>`, different default parameter settings can be added for new nodes that are created. Existing nodes will not be affected.
 
 ```bash
 > rfsim 1
@@ -793,6 +800,7 @@ cslacc               20 (PPM)
 cslunc               10 (10-us)
 txintf               0 (%)
 clkdrift             0 (PPM)
+bitrate              250000 (bps)
 Done
 > rfsim 1 cslacc 45
 Done
@@ -806,8 +814,19 @@ cslacc               45 (PPM)
 cslunc               10 (10-us)
 txintf               0 (%)
 clkdrift             0 (PPM)
+bitrate              250000 (bps)
 Done
 >
+```
+
+In the below example, the default PHY bitrate is set to 100 kbps for any new nodes that are created afterwards.
+
+```bash
+> rfsim default bitrate 100000
+Done
+> rfsim default
+bitrate               100000 (bps)
+Done
 ```
 
 ### save

--- a/cli/ast.go
+++ b/cli/ast.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The OTNS Authors.
+// Copyright (c) 2020-2025, The OTNS Authors.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -517,11 +517,12 @@ type RadioParamCmd struct {
 
 // noinspection GoVetStructTag
 type RfSimCmd struct {
-	Cmd   struct{}     `"rfsim"`      //nolint
-	Id    NodeSelector `@@`           //nolint
-	Param string       `[@Ident]`     //nolint
-	Sign  string       `[@("-"|"+")]` //nolint
-	Val   *int         `[ @Int ]`     //nolint
+	Cmd     struct{}      `"rfsim"`      //nolint
+	Default *DefaultFlag  `[@@|`         //nolint
+	Id      *NodeSelector `@@]`          //nolint
+	Param   string        `[@Ident]`     //nolint
+	Sign    string        `[@("-"|"+")]` //nolint
+	Val     *int          `[ @Int ]`     //nolint
 }
 
 // noinspection GoVetStructTag

--- a/ot-rfsim/src/event-sim.c
+++ b/ot-rfsim/src/event-sim.c
@@ -176,7 +176,7 @@ void otSimSendRfSimParamRespEvent(uint8_t param, int32_t value)
     memcpy(event.mData + 1, &value, sizeof(int32_t));
     event.mEvent      = OT_SIM_EVENT_RFSIM_PARAM_RSP;
     event.mDelay      = 0;
-    event.mDataLength = sizeof(int32_t) + 1;
+    event.mDataLength = sizeof(uint8_t) + sizeof(int32_t);
 
     otSimSendEvent(&event);
 }

--- a/ot-rfsim/src/radio.h
+++ b/ot-rfsim/src/radio.h
@@ -47,10 +47,11 @@ enum
     OT_RADIO_AIFS_TIME_US           = 12 * OT_RADIO_SYMBOL_TIME, // From 802.15.4 spec, AIFS
     OT_RADIO_CCA_TIME_US            = 8 * OT_RADIO_SYMBOL_TIME,  // From 802.15.4 spec, CCA duration
     OT_RADIO_SHR_DURATION_US        = 5 * OT_RADIO_SYMBOLS_PER_OCTET * OT_RADIO_SYMBOL_TIME, // sync header (SHR)
-    OT_RADIO_SHR_PHR_DURATION_US    = 6 * OT_RADIO_SYMBOLS_PER_OCTET * OT_RADIO_SYMBOL_TIME, // SHR + PHY header (PHR)
-    OT_RADIO_MAX_TURNAROUND_TIME_US = 12 * OT_RADIO_SYMBOL_TIME, // specified max turnaround time.
+    OT_RADIO_SHR_PHR_LENGTH_BYTES   = 6, // SHR + PHY header (PHR) length in bytes
+    OT_RADIO_SHR_PHR_DURATION_US    = OT_RADIO_SHR_PHR_LENGTH_BYTES * OT_RADIO_SYMBOLS_PER_OCTET * OT_RADIO_SYMBOL_TIME,
+    OT_RADIO_MAX_TURNAROUND_TIME_US = 12 * OT_RADIO_SYMBOL_TIME, // specified max turnaround time
     OT_RADIO_MAX_ACK_WAIT_US        = (OT_RADIO_AIFS_TIME_US + (10 * OT_RADIO_SYMBOL_TIME)),
-    OT_RADIO_aMaxSifsFrameSize      = 18, // From 802.15.4 spec - frame size considered 'short'
+    OT_RADIO_aMaxSifsFrameSize      = 18, // From 802.15.4 spec - max frame size considered 'short'
 };
 
 // Wi-Fi 802.11n related parameters. See radio-parameters.h for radio-model-specific Wi-Fi parameters.
@@ -78,6 +79,7 @@ typedef enum
     RFSIM_PARAM_CSL_UNCERTAINTY,
     RFSIM_PARAM_TX_INTERFERER,
     RFSIM_PARAM_CLOCK_DRIFT,
+    RFSIM_PARAM_PHY_BITRATE,
     RFSIM_PARAM_UNKNOWN = 255,
 } RfSimParam;
 

--- a/simulation/node.go
+++ b/simulation/node.go
@@ -32,6 +32,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -409,7 +410,8 @@ func (node *Node) GetRfSimParam(param RfSimParam) RfSimParamValue {
 		ParamCslUncertainty,
 		ParamTxInterferer,
 		ParamClockDrift,
-		ParamCslAccuracy:
+		ParamCslAccuracy,
+		ParamPhyBitrate:
 		return node.getOrSetRfSimParam(false, param, 0)
 	case ParamCcaThreshold:
 		return node.GetCcaThreshold()
@@ -423,7 +425,7 @@ func (node *Node) SetRfSimParam(param RfSimParam, value RfSimParamValue) {
 	switch param {
 	case ParamRxSensitivity:
 		if value < RssiMin || value > RssiMax {
-			node.error(fmt.Errorf("parameter out of range %d to %d", RssiMin, RssiMax))
+			node.error(fmt.Errorf("parameter out of range %d - %d", RssiMin, RssiMax))
 			return
 		}
 		node.getOrSetRfSimParam(true, param, value)
@@ -438,8 +440,14 @@ func (node *Node) SetRfSimParam(param RfSimParam, value RfSimParamValue) {
 	case ParamCcaThreshold:
 		node.SetCcaThreshold(value)
 	case ParamClockDrift:
-		if value < -127 || value > 127 {
-			node.error(fmt.Errorf("parameter out of range -127 - +127"))
+		if value < math.MinInt16 || value > math.MaxInt16 {
+			node.error(fmt.Errorf("parameter out of range %d - %d", math.MinInt16, math.MaxInt16))
+			return
+		}
+		node.getOrSetRfSimParam(true, param, value)
+	case ParamPhyBitrate:
+		if value < 1 || value > RfSimValueMax {
+			node.error(fmt.Errorf("parameter out of range 1 - %d", RfSimValueMax))
 			return
 		}
 		node.getOrSetRfSimParam(true, param, value)

--- a/simulation/node_config.go
+++ b/simulation/node_config.go
@@ -163,6 +163,7 @@ func DefaultNodeConfig() NodeConfig {
 		Restore:        false,
 		InitScript:     []string{},
 		RandomSeed:     0, // 0 means not specified, i.e. truly unpredictable.
+		RfSimParams:    map[RfSimParam]RfSimParamValue{},
 	}
 }
 

--- a/simulation/simulation.go
+++ b/simulation/simulation.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The OTNS Authors.
+// Copyright (c) 2020-2025, The OTNS Authors.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -173,7 +173,7 @@ func (s *Simulation) AddNode(cfg *NodeConfig) (*Node, error) {
 	logger.AssertFalse(s.d.IsAlive(nodeid))
 
 	// run setup and script(s) for the node
-	node.Logger.Debugf("start setup of node (version/commit, mode, init script)")
+	node.Logger.Debugf("start setup of node (version/commit, rfsim params, mode, init script)")
 	ver := node.GetVersion()
 	if err = node.CommandResult(); err != nil {
 		return nil, err
@@ -190,6 +190,13 @@ func (s *Simulation) AddNode(cfg *NodeConfig) (*Node, error) {
 		ThreadVersion: threadVer,
 	}
 	s.vis.SetNetworkInfo(nodeInfo)
+
+	for rfSimParam, rfSimParamValue := range cfg.RfSimParams {
+		node.SetRfSimParam(rfSimParam, rfSimParamValue)
+		if err = node.CommandResult(); err != nil {
+			return nil, err
+		}
+	}
 
 	if !cfg.IsRaw {
 		node.setupMode()

--- a/types/node_config.go
+++ b/types/node_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The OTNS Authors.
+// Copyright (c) 2020-2025, The OTNS Authors.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -45,6 +45,7 @@ type NodeConfig struct {
 	Restore        bool
 	InitScript     []string // a sequence of CLI commands executed at first startup of node
 	RandomSeed     int32
+	RfSimParams    map[RfSimParam]RfSimParamValue // optional modified RF simulation parameters
 }
 
 // UpdateNodeConfigFromType sets NodeConfig flags correctly, based on chosen node type cfg.Type

--- a/types/rfsim_types.go
+++ b/types/rfsim_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024, The OTNS Authors.
+// Copyright (c) 2023-2025, The OTNS Authors.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -114,6 +114,7 @@ const (
 	ParamCslUncertainty RfSimParam = 3
 	ParamTxInterferer   RfSimParam = 4
 	ParamClockDrift     RfSimParam = 5
+	ParamPhyBitrate     RfSimParam = 6
 	ParamUnknown        RfSimParam = 255
 )
 
@@ -122,12 +123,13 @@ type RfSimParamValue int32
 
 const (
 	RfSimValueInvalid RfSimParamValue = math.MaxInt32
+	RfSimValueMax     RfSimParamValue = RfSimValueInvalid - 1
 )
 
 var RfSimParamsList = []RfSimParam{ParamRxSensitivity, ParamCcaThreshold, ParamCslAccuracy, ParamCslUncertainty,
-	ParamTxInterferer, ParamClockDrift}
-var RfSimParamNamesList = []string{"rxsens", "ccath", "cslacc", "cslunc", "txintf", "clkdrift"}
-var RfSimParamUnitsList = []string{"dBm", "dBm", "PPM", "10-us", "%", "PPM"}
+	ParamTxInterferer, ParamClockDrift, ParamPhyBitrate}
+var RfSimParamNamesList = []string{"rxsens", "ccath", "cslacc", "cslunc", "txintf", "clkdrift", "bitrate"}
+var RfSimParamUnitsList = []string{"dBm", "dBm", "PPM", "10-us", "%", "PPM", "bps"}
 
 func ParseRfSimParam(parName string) RfSimParam {
 	for i := 0; i < len(RfSimParamsList); i++ {

--- a/types/types.go
+++ b/types/types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024, The OTNS Authors.
+// Copyright (c) 2022-2025, The OTNS Authors.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
This adds a 'bitrate' rfsim parameter for setting PHY bitrate per node. This parameter determines the time duration of a packet transmission.

The command `rfsim default` is added to set default rfsim parameters (such as bitrate or others) for every new node that is created from then on. This is useful to set at OTNS startup (e.g. in a script), to ensure that all nodes speak the same bitrate.