### PR TITLE
[docker] provide more help to user for 'playground' Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ To do a quick try-out of OTNS without installing any software locally, you can f
 docker run -it -p 8997-9000:8997-9000 openthread/otns-playground
 ```
 
+The playground has some limitations: by default, any save/load operations are confined to the container's file system and will be lost when the container stops. To persist data, use Docker's -v flag to mount a volume. Additionally, the 'web' command does not work.
+
 # Contributing
 
 We would love for you to contribute to OTNS and help make it even better than it is today! See our [Contributing Guidelines](CONTRIBUTING.md) for more information.

--- a/etc/docker/playground/run-playground.sh
+++ b/etc/docker/playground/run-playground.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Copyright (c) 2025, The OTNS Authors.
+#
+# Copyright (c) 2025-2026, The OTNS Authors.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -29,9 +30,12 @@
 # exposed to the host, and show a clickable link to open the web GUI.
 
 echo "OTNS playground - use this Docker for a first try of the OpenThread Network Simulator (OTNS)."
-echo
+echo ""
+echo "To run this container correctly with ports exposed for your web browser, use:"
+echo "   docker run -it -p 8997-9000:8997-9000 openthread/otns-playground"
+echo ""
 echo "Open below link in a browser for the GUI, e.g. right-click & select 'Open Link':"
 echo "   http://localhost:8997/visualize?addr=localhost:8998"
-echo
+echo ""
 echo "OTNS CLI prompt - type 'help' for a command overview."
 otns "-listen" "0.0.0.0:9000" "$@"


### PR DESCRIPTION
This adds a startup message on how to run the Playground Docker correctly. This is helpful for users that just start it in the default way using 'docker run' without the ports exposed or without the '-it' flags: they can easily retry and get it to work.