### PR TITLE
[script] install nodes in ~/.local/share/otns so that OTNS can run from anywhere

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2025, The OTNS Authors.
+# Copyright (c) 2020-2026, The OTNS Authors.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -58,7 +58,7 @@ jobs:
       - name: Build
         run: |
           ./script/install-deps
-          ./script/install
+          ./script/install-otns
 
   build-nodes:
     name: Build Nodes (${{ matrix.os }})

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2025, The OTNS Authors.
+# Copyright (c) 2020-2026, The OTNS Authors.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -77,7 +77,7 @@ jobs:
             git diff
             exit 1
           fi
-          ./script/install
+          ./script/install-otns
       - name: Build custom OT node
         # FIXME: OT_CMAKE_NINJA_TARGET used to exclude tests, because test_platform.cpp is missing otPlatAssertFail()
         run: |

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -52,7 +52,7 @@ Running this script will also set up a Python 3 virtual environment (venv) in `.
 #### Install OTNS
 
 ```bash
-./script/install
+./script/install-otns
 ```
 
 This installs `otns` in the Go binary directory of the user (typically `~/go/bin`) and makes the command available in the path. Also, it installs the pyOTNS library in the local Python virtual environment `.venv-otns`. The OT nodes required for running a simulation are not yet installed at this point: this is the next step.

--- a/ot-rfsim/ot-versions/README.md
+++ b/ot-rfsim/ot-versions/README.md
@@ -18,4 +18,6 @@ Versions are listed below. With each version tag, the directory is listed in whi
 
 - br-ccm - `openthread-ccm` - (In development) A Thread CCM Border Router.
 
-Build scripts: the build scripts to build all of the versions are `../script/build_<version-tag>`. Each of these specific build scripts invokes the general `build` script. The `../script/build_all` builds all commonly used versions.
+Build scripts: the build scripts to build all of the versions are `./script/build_<version-tag>`, which are invoked from the `./ot-rfsim` directory. Each of these specific build scripts invokes the general `build` script. The `./script/build_all` builds all commonly used versions.
+
+Note: all build scripts copy the resulting executables to the `./ot-rfsim/ot-versions` directory. Before OTNS will use these executables, they must be copied to the `~/.local/share/otns/bin` directory. This is done by the installation script `./script/install-nodes` which is invoked from the main OTNS repo directory.

--- a/script/install
+++ b/script/install
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020-2025, The OTNS Authors.
+# Copyright (c) 2020-2026, The OTNS Authors.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -25,31 +25,25 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# Installs OTNS (without any OT node executables) and pyOTNS.
+# Installs OTNS in ~/go/bin, pyOTNS, and all nodes in ~/.local/share/otns
 
 # shellcheck source=script/common.sh
 . "$(dirname "$0")"/common.sh
 
 install_otns()
 {
-    go mod tidy
-    repeat 3 go_install ./cmd/...
-    echo "otns installed: $(command -v otns)"
+    ./script/install-otns
 }
 
-install_pyotns()
+install_nodes()
 {
-    activate_python_venv
-    cd pylibs
-    python3 -m pip install .
-    # python3 setup.py install --user --prefix= 2>/dev/null  #  alternative - fails on macos-14
-    cd -
+    ./script/install-nodes
 }
 
 main()
 {
-    install_pyotns
     install_otns
+    install_nodes
 }
 
 main

--- a/script/install-nodes
+++ b/script/install-nodes
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024-2025, The OTNS Authors.
+# Copyright (c) 2024-2026, The OTNS Authors.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -31,9 +31,16 @@
 # shellcheck source=script/common.sh
 . "$(dirname "$0")"/common.sh
 
+install_nodes_to_local_share()
+{
+    mkdir -p ~/.local/share/otns/bin
+    cp ./ot-rfsim/ot-versions/* ~/.local/share/otns/bin/
+}
+
 main()
 {
     build_openthread_versions
+    install_nodes_to_local_share
 }
 
 main

--- a/script/install-otns
+++ b/script/install-otns
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright (c) 2020-2026, The OTNS Authors.
 # All rights reserved.
 #
@@ -24,40 +25,31 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-name: Lint
+# Installs OTNS (without any OT node executables) and pyOTNS.
 
-on:
-  push:
-    branches-ignore:
-      - 'dependabot/**'
-  pull_request:
-    branches:
-      - 'main'
+# shellcheck source=script/common.sh
+. "$(dirname "$0")"/common.sh
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.repository == 'openthread/ot-ns' && github.run_id) || github.ref }}
-  cancel-in-progress: true
+install_otns()
+{
+    go mod tidy
+    repeat 3 go_install ./cmd/...
+    echo "otns installed: $(command -v otns)"
+}
 
-permissions:
-  contents: read
+install_pyotns()
+{
+    activate_python_venv
+    cd pylibs || die "required directory 'pylibs' not found"
+    python3 -m pip install .
+    # python3 setup.py install --user --prefix= 2>/dev/null  #  alternative - fails on macos-14
+    cd - || die "cd failed"
+}
 
-jobs:
-  go-lint:
-    name: Go/Shell/Python/C/Markdown Lint
-    runs-on: ubuntu-24.04
-    env:
-      HOMEBREW_NO_AUTO_UPDATE: 1
-    steps:
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
-        with:
-          go-version: '1.23'
-      - name: Bootstrap
-        run: |
-          sudo apt-get update
-          sudo apt-get --no-install-recommends install -y clang-format-19 clang-tidy-19
-      - name: Check pretty
-        run: |
-          ./script/install-deps
-          ./script/install-otns
-          ./script/make-pretty check
+main()
+{
+    install_pyotns
+    install_otns
+}
+
+main

--- a/script/test
+++ b/script/test
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020-2025, The OTNS Authors.
+# Copyright (c) 2020-2026, The OTNS Authors.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -80,7 +80,7 @@ install_deps()
 
 install_otns()
 {
-    ./script/install
+    ./script/install-otns
 }
 
 py_unittests()

--- a/simulation/node_config.go
+++ b/simulation/node_config.go
@@ -144,7 +144,7 @@ var DefaultExecutableConfig ExecutableConfig = ExecutableConfig{
 	Mtd:         "ot-cli-mtd",
 	Br:          "ot-cli-ftd_br",
 	Matter:      "ot-matter-node",
-	SearchPaths: []string{".", "./ot-rfsim/ot-versions", "./build/bin"},
+	SearchPaths: []string{".", filePathInUserHomeDir(".local/share/otns/bin"), "./ot-rfsim/ot-versions"},
 }
 
 func DefaultNodeConfig() NodeConfig {
@@ -280,7 +280,7 @@ func (cfg *ExecutableConfig) FindExecutable(exeName string) string {
 			return "./" + exePath
 		}
 	}
-	// if not found, try to relay on OS $PATH to find the executables.
+	// if not found, try to rely on OS $PATH to find the executables.
 	return exeName
 }
 

--- a/simulation/utils.go
+++ b/simulation/utils.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The OTNS Authors.
+// Copyright (c) 2020-2026, The OTNS Authors.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -36,6 +36,14 @@ import (
 
 	"golang.org/x/net/ipv6"
 )
+
+func filePathInUserHomeDir(relPath string) string {
+	home, err := os.UserHomeDir()
+	if err == nil {
+		return filepath.Join(home, relPath)
+	}
+	return "/tmp/UserHomeDirNotFound"
+}
 
 func removeAllFiles(globPath string) error {
 	files, err := filepath.Glob(globPath)


### PR DESCRIPTION
The installation is updated to copy node executables to a .local/share directory. This directory is added to the node search path, so that standard OT node executables can be found from any directory location where OTNS is run from. The build and copying of node executables is added to the './script/install' script.

Close #587