### PR TITLE
Fix unauthenticated file overwrite and path traversal

### DIFF
--- a/cli/CmdRunner.go
+++ b/cli/CmdRunner.go
@@ -1353,10 +1353,16 @@ func (rt *CmdRunner) executeKpi(cc *CommandContext, cmd *KpiCmd) {
 func (rt *CmdRunner) executeSave(cc *CommandContext, cmd *SaveCmd) {
 	var rootYaml yaml.Node
 
+	safeFilename, err := simulation.CheckSafePath(cmd.Filename)
+	if err != nil {
+		cc.errorf("Invalid save file name: %v", err)
+		return
+	}
+
 	// test filename if valid
-	_, err := os.Stat(cmd.Filename)
+	_, err = os.Stat(safeFilename)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		cc.errorf("Invalid save file name: %s", cmd.Filename)
+		cc.errorf("Invalid save file name: %s", safeFilename)
 		return
 	}
 
@@ -1368,31 +1374,38 @@ func (rt *CmdRunner) executeSave(cc *CommandContext, cmd *SaveCmd) {
 			NetworkConfig: networkConfig,
 			NodesList:     nodesConfig,
 		}
-		err = rootYaml.Encode(root)
+		err := rootYaml.Encode(root)
 		logger.PanicIfError(err)
 
-		var data []byte
-		data, err = yaml.Marshal(&rootYaml)
-		err = os.WriteFile(cmd.Filename, data, 0644)
+		data, err := yaml.Marshal(&rootYaml)
+		if err != nil {
+			cc.errorf("Error marshaling YAML: %v", err)
+			return
+		}
+		if err := os.WriteFile(safeFilename, data, 0644); err != nil {
+			cc.errorf("Error writing file '%s': %v", safeFilename, err)
+		}
 	})
-
-	if err != nil {
-		cc.errorf("Error writing file '%s': %v", cmd.Filename, err)
-	}
 }
 
 func (rt *CmdRunner) executeLoad(cc *CommandContext, cmd *LoadCmd) {
+	safeFilename, err := simulation.CheckSafePath(cmd.Filename)
+	if err != nil {
+		cc.errorf("Invalid load file name: %v", err)
+		return
+	}
+
 	// test filename if valid
-	fileInfo, err := os.Stat(cmd.Filename)
+	fileInfo, err := os.Stat(safeFilename)
 	if err != nil || fileInfo.IsDir() {
-		cc.errorf("Invalid load file name: %s", cmd.Filename)
+		cc.errorf("Invalid load file name: %s", safeFilename)
 		return
 	}
 
 	rt.postAsyncWait(cc, func(sim *simulation.Simulation) {
-		b, err := os.ReadFile(cmd.Filename)
+		b, err := os.ReadFile(safeFilename)
 		if err != nil {
-			cc.errorf("Could not load file '%s': %v", cmd.Filename, err)
+			cc.errorf("Could not load file '%s': %v", safeFilename, err)
 			return
 		}
 		cfgFile := simulation.YamlConfigFile{}

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -30,11 +30,13 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/openthread/ot-ns/simulation"
 	. "github.com/openthread/ot-ns/types"
 )
 
@@ -332,4 +334,37 @@ func TestNodeSelectorUniqueSorted(t *testing.T) {
 	exp = []NodeSelector{{All: &allStr}}
 	outp = getUniqueAndSorted(inp)
 	assert.Equal(t, exp, outp)
+}
+
+func TestCheckSafePath(t *testing.T) {
+	cwd, err := os.Getwd()
+	assert.Nil(t, err)
+	evalCwd, err := filepath.EvalSymlinks(cwd)
+	if err != nil {
+		evalCwd = cwd
+	}
+
+	safe, err := simulation.CheckSafePath("valid_filename.yaml")
+	assert.Nil(t, err)
+	assert.Equal(t, filepath.Join(evalCwd, "valid_filename.yaml"), safe)
+
+	safe, err = simulation.CheckSafePath("sub/dir/test.yaml")
+	assert.Nil(t, err)
+	assert.Equal(t, filepath.Join(evalCwd, "sub/dir/test.yaml"), safe)
+
+	safe, err = simulation.CheckSafePath("..foo.yaml")
+	assert.Nil(t, err)
+	assert.Equal(t, filepath.Join(evalCwd, "..foo.yaml"), safe)
+
+	_, err = simulation.CheckSafePath("../outside.yaml")
+	assert.NotNil(t, err)
+
+	_, err = simulation.CheckSafePath("sub/../../outside.yaml")
+	assert.NotNil(t, err)
+
+	_, err = simulation.CheckSafePath("/etc/passwd")
+	assert.NotNil(t, err)
+
+	_, err = simulation.CheckSafePath("")
+	assert.NotNil(t, err)
 }

--- a/energy/core.go
+++ b/energy/core.go
@@ -30,6 +30,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/openthread/ot-ns/logger"
 )
@@ -110,8 +111,17 @@ func (e *EnergyAnalyser) SaveEnergyDataToFile(name string, timestamp uint64) {
 		}
 	}
 
+	if name == "." || name == ".." || strings.ContainsAny(name, "/\\") {
+		logger.Errorf("Invalid energy result file name: %s", name)
+		return
+	}
+
 	//Get current directory and add name to the path
-	dir, _ := os.Getwd()
+	dir, err := os.Getwd()
+	if err != nil {
+		logger.Errorf("Failed to get current working directory: %v", err)
+		return
+	}
 
 	//create "energy_results" directory if it does not exist
 	if _, err := os.Stat(dir + "/energy_results"); os.IsNotExist(err) {

--- a/simulation/kpi.go
+++ b/simulation/kpi.go
@@ -31,6 +31,8 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/openthread/ot-ns/dispatcher"
@@ -102,8 +104,66 @@ func (km *KpiManager) SaveDefaultFile() {
 	km.SaveFile(km.getDefaultSaveFileName())
 }
 
+// CheckSafePath validates that the given filename is safe and within the current working directory.
+func CheckSafePath(filename string) (string, error) {
+	if len(filename) == 0 {
+		return "", fmt.Errorf("empty file path")
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	evalCwd, err := filepath.EvalSymlinks(cwd)
+	if err != nil {
+		evalCwd = cwd
+	}
+
+	abs, err := filepath.Abs(filename)
+	if err != nil {
+		return "", err
+	}
+
+	evalAbs := abs
+	temp := abs
+	var rest []string
+	for {
+		eval, err := filepath.EvalSymlinks(temp)
+		if err == nil {
+			evalAbs = eval
+			for i := len(rest) - 1; i >= 0; i-- {
+				evalAbs = filepath.Join(evalAbs, rest[i])
+			}
+			break
+		}
+		parent := filepath.Dir(temp)
+		if parent == temp {
+			break
+		}
+		rest = append(rest, filepath.Base(temp))
+		temp = parent
+	}
+
+	rel, err := filepath.Rel(evalCwd, evalAbs)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("access outside working directory is not allowed: %s", filename)
+	}
+
+	return evalAbs, nil
+}
+
 func (km *KpiManager) SaveFile(fn string) {
 	logger.AssertNotNil(km.sim)
+	var cleanFn string
+	var err error
+	if fn == km.getDefaultSaveFileName() {
+		cleanFn = fn
+	} else {
+		cleanFn, err = CheckSafePath(fn)
+		if err != nil {
+			logger.Errorf("Invalid KPI JSON file name: %v", err)
+			return
+		}
+	}
 	if km.isRunning {
 		km.curCounters = km.retrieveNodeCounters()
 		km.curRadioStats = km.retrieveRadioModelStats()
@@ -118,9 +178,9 @@ func (km *KpiManager) SaveFile(fn string) {
 		return
 	}
 
-	err = os.WriteFile(fn, jsn, 0644)
+	err = os.WriteFile(cleanFn, jsn, 0644)
 	if err != nil {
-		logger.Errorf("Could not write  KPI JSON file %s: %v", fn, err)
+		logger.Errorf("Could not write  KPI JSON file %s: %v", cleanFn, err)
 		return
 	}
 }

--- a/visualize/grpc/grpcServer.go
+++ b/visualize/grpc/grpcServer.go
@@ -147,7 +147,23 @@ func (gs *grpcServer) Command(ctx context.Context, req *pb.CommandRequest) (*pb.
 }
 
 func (gs *grpcServer) Run() error {
-	lis, err := net.Listen("tcp", gs.address)
+	address := gs.address
+	if address == "" {
+		address = "127.0.0.1:0"
+	} else if host, port, err := net.SplitHostPort(address); err == nil {
+		if ip := net.ParseIP(host); ip != nil {
+			if ip.IsUnspecified() {
+				if ip.To4() != nil {
+					address = net.JoinHostPort("127.0.0.1", port)
+				} else {
+					address = net.JoinHostPort("::1", port)
+				}
+			}
+		} else if host == "" || host == "0" {
+			address = net.JoinHostPort("127.0.0.1", port)
+		}
+	}
+	lis, err := net.Listen("tcp", address)
 	if err != nil {
 		return err
 	}

--- a/visualize/grpc/grpcServer_test.go
+++ b/visualize/grpc/grpcServer_test.go
@@ -75,3 +75,23 @@ func TestStopBeforeStart(t *testing.T) {
 	assert.NotNil(t, err, "expected Run() error but got nil")
 	logger.Infof("Run() err returned: %v", err)
 }
+
+func TestWildcardAddressLoopbackBinding(t *testing.T) {
+	vis := &grpcVisualizer{
+		simctrl: nil,
+		f:       newGrpcField(),
+	}
+	srv := newGrpcServer(vis, "0.0.0.0:0", nil)
+
+	var err error
+	done := make(chan bool)
+	go func() {
+		err = srv.Run()
+		done <- true
+	}()
+	time.Sleep(time.Second * 1)
+	srv.stop()
+
+	<-done
+	assert.Nil(t, err, "expected nil Run() error but got %v", err)
+}


### PR DESCRIPTION
Enforce loopback address for gRPC visualizer server and sanitize file paths across CLI save, load, KPI, and energy export commands.

Changes:
- Enforce 127.0.0.1 binding in visualize/grpc/grpcServer.go if a wildcard or empty listening host is supplied.
- Add checkSafePath validation in cli/CmdRunner.go to reject path traversal ('..') and restrict file access to working directory.
- Validate and sanitize file paths in simulation/kpi.go and energy/core.go.
- Add unit tests for checkSafePath in cli/cli_test.go.