### PR TITLE
submodule: bump openthread from `5cf4256` to `044aa98`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,13 +49,14 @@ jobs:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.23'
       - name: Bootstrap
         run: |
-          sudo apt-get update
-          sudo apt-get --no-install-recommends install -y clang-format-19 clang-tidy-19
+          sudo bash openthread/script/install-llvm.sh
       - name: Check pretty
         run: |
           ./script/install-deps

--- a/ot-rfsim/src/radio.c
+++ b/ot-rfsim/src/radio.c
@@ -926,7 +926,7 @@ uint8_t otPlatRadioGetCslUncertainty(otInstance *aInstance)
 
 void otPlatRadioSetMacKey(otInstance             *aInstance,
                           uint8_t                 aKeyIdMode,
-                          uint8_t                 aKeyId,
+                          uint8_t                 aKeyIndex,
                           const otMacKeyMaterial *aPrevKey,
                           const otMacKeyMaterial *aCurrKey,
                           const otMacKeyMaterial *aNextKey,
@@ -937,7 +937,7 @@ void otPlatRadioSetMacKey(otInstance             *aInstance,
 
     otEXPECT(aPrevKey != NULL && aCurrKey != NULL && aNextKey != NULL);
 
-    sKeyId   = aKeyId;
+    sKeyId   = aKeyIndex;
     sKeyType = aKeyType;
     memcpy(&sPrevKey, aPrevKey, sizeof(otMacKeyMaterial));
     memcpy(&sCurrKey, aCurrKey, sizeof(otMacKeyMaterial));


### PR DESCRIPTION
Bumps openthread from `5cf4256` to `044aa98` and updates lint workflow to install LLVM 19 toolchain via OpenThread's install-llvm.sh.