### PR TITLE
[rfsim] return OT_ERROR_NONE on delayed sleep in `otPlatRadioSleep`

### DIFF
--- a/ot-rfsim/src/radio.c
+++ b/ot-rfsim/src/radio.c
@@ -360,7 +360,7 @@ otError otPlatRadioSleep(otInstance *aInstance)
     if (sSubState == RFSIM_RADIO_SUBSTATE_RX_FRAME_ONGOING || sSubState == RFSIM_RADIO_SUBSTATE_RX_ACK_TX_ONGOING ||
         sSubState == RFSIM_RADIO_SUBSTATE_RX_AIFS_WAIT)
     {
-        error       = OT_ERROR_BUSY;
+        error       = OT_ERROR_NONE;
         sDelaySleep = true;
     }
     else if (sState == OT_RADIO_STATE_SLEEP || sState == OT_RADIO_STATE_RECEIVE)


### PR DESCRIPTION
When `otPlatRadioSleep()` is called while the radio is receiving an incoming frame, waiting in AIFS, or actively transmitting an auto-ACK, `ot-rfsim` schedules a delayed transition to sleep (`sDelaySleep = true`) which takes effect once the ongoing frame/ACK operation completes.

Previously, `otPlatRadioSleep()` returned `OT_ERROR_BUSY` in these substates which would be incorrect. The radio driver must accept the sleep request and transition to sleep after finishing the current atomic operation without returning an error.

This commit updates `otPlatRadioSleep()` to return `OT_ERROR_NONE` when scheduling delayed sleep, indicating that the sleep request has been successfully accepted.