### PR TITLE
[rfsim] fix delayed sleep handling and align with radio API

### DIFF
--- a/ot-rfsim/src/radio.c
+++ b/ot-rfsim/src/radio.c
@@ -340,9 +340,8 @@ otError otPlatRadioDisable(otInstance *aInstance)
     otError error = OT_ERROR_NONE;
 
     otEXPECT(otPlatRadioIsEnabled(aInstance));
+    applyRadioDelayedSleep(); // a pending sleep is immediately performed
     otEXPECT_ACTION(sState == OT_RADIO_STATE_SLEEP, error = OT_ERROR_INVALID_STATE);
-
-    sDelaySleep = false;
     setRadioState(OT_RADIO_STATE_DISABLED);
 
 exit:
@@ -357,8 +356,12 @@ otError otPlatRadioSleep(otInstance *aInstance)
 
     otError error = OT_ERROR_INVALID_STATE;
 
-    if (sSubState == RFSIM_RADIO_SUBSTATE_RX_FRAME_ONGOING || sSubState == RFSIM_RADIO_SUBSTATE_RX_ACK_TX_ONGOING ||
-        sSubState == RFSIM_RADIO_SUBSTATE_RX_AIFS_WAIT)
+    if (sState == OT_RADIO_STATE_TRANSMIT)
+    {
+        error = OT_ERROR_BUSY;
+    }
+    else if (sSubState == RFSIM_RADIO_SUBSTATE_RX_FRAME_ONGOING ||
+             sSubState == RFSIM_RADIO_SUBSTATE_RX_ACK_TX_ONGOING || sSubState == RFSIM_RADIO_SUBSTATE_RX_AIFS_WAIT)
     {
         error       = OT_ERROR_NONE;
         sDelaySleep = true;
@@ -381,10 +384,17 @@ otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 
     otError error = OT_ERROR_INVALID_STATE;
 
-    if (sState != OT_RADIO_STATE_DISABLED)
+    if (sState != OT_RADIO_STATE_DISABLED && sState != OT_RADIO_STATE_TRANSMIT)
     {
-        if (sState == OT_RADIO_STATE_SLEEP && sSubState != RFSIM_RADIO_SUBSTATE_STARTUP)
+        // An Ack Tx already on air cannot be recalled from the simulator: let it finish. The channel
+        // change is then applied when the substate machine reaches Ready again.
+        // TODO: consider to fix the Go radio model to detect a radio aborting (due to power/chan change)
+        bool isAckOnAir = (sSubState == RFSIM_RADIO_SUBSTATE_RX_ACK_TX_ONGOING);
+
+        if (!isAckOnAir && ((sState == OT_RADIO_STATE_SLEEP && sSubState != RFSIM_RADIO_SUBSTATE_STARTUP) ||
+                            aChannel != sCurrentChannel))
         {
+            // Going from sleep to receive, or a channel change, incurs the ramp-up time.
             setRadioSubState(RFSIM_RADIO_SUBSTATE_STARTUP, RFSIM_RAMPUP_TIME_US);
         }
         error                  = OT_ERROR_NONE;
@@ -732,6 +742,7 @@ otError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint1
     sEnergyScanResult  = OT_RADIO_RSSI_INVALID;
     sEnergyScanning    = true;
     sEnergyScanEndTime = otPlatAlarmMilliGetNow() + aScanDuration;
+    sDelaySleep        = false;
 
 exit:
     return error;
@@ -1152,8 +1163,8 @@ void setRadioState(otRadioState aState)
         switch (aState)
         {
         case OT_RADIO_STATE_DISABLED:
-            // force the radio to stop, resetting substate. Enabling again would take the startup time.
-            setRadioSubState(RFSIM_RADIO_SUBSTATE_STARTUP, RFSIM_STARTUP_TIME_US);
+            // force the radio to stop, resetting substate to base 'ready'.
+            setRadioSubState(RFSIM_RADIO_SUBSTATE_READY, UNDEFINED_TIME_US);
             break;
         default:
             break;
@@ -1239,6 +1250,8 @@ void platformRadioRxDone(otInstance                *aInstance,
     sReceiveFrame.mInfo.mRxInfo.mRssi = aRxParams->mPower;
     sReceiveFrame.mInfo.mRxInfo.mLqi  = OT_RADIO_LQI_NONE; // No support of LQI reporting.
 
+    radioReceive(aInstance, aRxParams->mError);
+
     bool isAck           = otMacFrameIsAck(&sReceiveFrame);
     bool isAckRequested  = otMacFrameIsAckRequested(&sReceiveFrame);
     bool isAddressedToMe = otMacFrameDoesAddrMatch(&sReceiveFrame, sPanId, sShortAddress, &sExtAddress);
@@ -1263,8 +1276,6 @@ void platformRadioRxDone(otInstance                *aInstance,
             (sTransmitFrame.mLength > OT_RADIO_aMaxSifsFrameSize) ? OT_RADIO_LIFS_TIME_US : OT_RADIO_SIFS_TIME_US;
         setRadioSubState(RFSIM_RADIO_SUBSTATE_IFS_WAIT, ifsTime);
     }
-
-    radioReceive(aInstance, aRxParams->mError);
 
 exit:
     return;
@@ -1307,6 +1318,7 @@ void platformRadioTxDone(otInstance *aInstance, struct RadioCommEventData *aTxDo
     if (sSubState == RFSIM_RADIO_SUBSTATE_RX_ACK_TX_ONGOING)
     {
         // Ack Tx is done now.
+        applyRadioDelayedSleep();
         setRadioSubState(RFSIM_RADIO_SUBSTATE_RX_TX_TO_RX, sTurnaroundTimeUs);
     }
     else if (sSubState == RFSIM_RADIO_SUBSTATE_TX_FRAME_ONGOING)
@@ -1429,7 +1441,8 @@ void platformRadioProcess(otInstance *aInstance)
             (sTransmitFrame.mLength > OT_RADIO_aMaxSifsFrameSize) ? OT_RADIO_LIFS_TIME_US : OT_RADIO_SIFS_TIME_US;
         switch (sSubState)
         {
-        case RFSIM_RADIO_SUBSTATE_STARTUP: // when radio/node starts.
+        case RFSIM_RADIO_SUBSTATE_STARTUP:              // when radio/node starts, or after a channel change.
+            sOngoingOperationChannel = sCurrentChannel; // startup done: radio now listens on the (new) channel.
             setRadioSubState(RFSIM_RADIO_SUBSTATE_READY, UNDEFINED_TIME_US);
             break;
 
@@ -1494,8 +1507,10 @@ void platformRadioProcess(otInstance *aInstance)
             // below is the state machine for Rx states.
         case RFSIM_RADIO_SUBSTATE_RX_FRAME_ONGOING:
             // wait until frame Rx is done. In platformRadioRxDone() the next state is selected.
-            // below is a timer-based failsafe in case the RxDone message from simulator was never received.
+            // this timer-based path is taken when no RxDone is received from the simulator: the normal
+            // case for a frame not addressed to me, and a failsafe if an RxDone was never sent.
             setRadioSubState(RFSIM_RADIO_SUBSTATE_IFS_WAIT, sTurnaroundTimeUs);
+            applyRadioDelayedSleep();
             break;
 
         case RFSIM_RADIO_SUBSTATE_RX_AIFS_WAIT:

--- a/ot-rfsim/src/radio.c
+++ b/ot-rfsim/src/radio.c
@@ -360,7 +360,7 @@ otError otPlatRadioSleep(otInstance *aInstance)
     if (sSubState == RFSIM_RADIO_SUBSTATE_RX_FRAME_ONGOING || sSubState == RFSIM_RADIO_SUBSTATE_RX_ACK_TX_ONGOING ||
         sSubState == RFSIM_RADIO_SUBSTATE_RX_AIFS_WAIT)
     {
-        error       = OT_ERROR_BUSY;
+        error       = OT_ERROR_NONE;
         sDelaySleep = true;
     }
     else if (sState == OT_RADIO_STATE_SLEEP || sState == OT_RADIO_STATE_RECEIVE)


### PR DESCRIPTION
Two commits:

[rfsim] fix delayed sleep and channel handling; align with OT radio API
    
    The delayed sleep scheduled by `otPlatRadioSleep()` was not always
    correctly applied. Also the channel information was not always
    correctly managed by the RFSIM radio, e.g. reporting incorrect Rx
    channel to the stack.
    
    This commit fixes these by calling `applyRadioDelayedSleep()` from more
    code paths and adds a companion function `applyPendingChannelChange()`
    to switch the channel, and apply radio ramp-up, as soon as an ongoing
    Rx operation is done.
    
    All radio platform functions are now aligned to comply with
    the clarified `otPlatRadio...()` API contract of OT PR #13580.
    
    Delayed sleep related changes:
    
     - `platformRadioTxDone()` now applies a pending sleep once the Ack Tx
       is done.
     - the `RX_FRAME_ONGOING` timer path in `platformRadioProcess()`
       applies a pending sleep too. That path is not only a failsafe: the
       simulator sends RxDone just to the frame's addressee, so it is the
       normal path for any frame that is overheard by a neighboring node.
     - `platformRadioRxDone()` calls `radioReceive()` now before the sub-
       state transitions, so that `otPlatRadioReceiveDone()` is invoked
       before the radio sleeps, as the API requires. Previously the sleep
       state was applied first, after which `radioReceive()` returned
       early and the received frame was silently dropped.
    
    API contract related changes:
    
     - `otPlatRadioSleep()` returns `OT_ERROR_BUSY` while transmitting.
     - `otPlatRadioDisable()` accepts a pending transition to sleep and
        enacts it; `OT_ERROR_INVALID_STATE` now means that the radio is
        neither in Sleep state nor transitioning to Sleep state.
     - `otPlatRadioReceive()` returns `OT_ERROR_INVALID_STATE` while
       transmitting, and models the radio ramp-up time when the receive
       channel is changed. An ongoing Rx operation (tested with
       `isRxOperationOngoing()` now) is now not aborted, which complies
       to the new API.
     - `otPlatRadioEnergyScan()` cancels a pending transition to sleep.
    
    Radio state machine:
    
     - `setRadioState(OT_RADIO_STATE_DISABLED)` resets the substate to
       Ready instead of Startup; the startup time is applied by
       `otPlatRadioEnable()`.
     - during ramp-up (STARTUP) of the radio `sOngoingOperationChannel`
       is already set to the channel to which it is ramping up.
       This fixes a bug that sometimes the node's radio stays registered
       on its previous channel in the simulator, causing it to miss
       frames.

    Channel handling:
    
     - `radioReceive()` tags a received frame with the channel it was
       received on (`sOngoingOperationChannel`); previously
       `otPlatRadioReceive()` set the requested channel, which could then
       mistakenly be used for transmitting the final Ack.
     - `otPlatRadioReceive()` models the ramp-up time on a channel change.
       During an ongoing Rx operation this change is deferred until that
       operation is done, so the node stays registered on the Rx channel in
       the simulator and the Ack is still sent.
     - `sOngoingOperationChannel` is set when ramp-up starts and again when
       it ends. Previously it was only updated in `platformRadioProcess()`,
       which runs after the radio state is reported to the simulator, so a
       node could sleep while still registered on its previous channel
       (from OTNS viewpoint) and miss frames.


[rfsim] return OT_ERROR_NONE on delayed sleep in `otPlatRadioSleep`
    
    When `otPlatRadioSleep()` is called while the radio is receiving an
    incoming frame, waiting in AIFS, or actively transmitting an auto-ACK,
    `ot-rfsim` schedules a delayed transition to sleep (`sDelaySleep = true`)
    which takes effect once the ongoing frame/ACK operation completes.
